### PR TITLE
feat: add complete frontend application

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,0 +1,6 @@
+node_modules
+npm-debug.log*
+dist
+.vite
+.DS_Store
+.env

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Gestión de Stock Thibe</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "gestionthibe-frontend",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "lint": "echo \"No hay reglas de lint configuradas\""
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.3"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.2.1",
+    "vite": "^5.2.0"
+  }
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,38 @@
+import { Navigate, Route, Routes } from 'react-router-dom';
+import ProtectedRoute from './components/ProtectedRoute.jsx';
+import AppLayout from './components/AppLayout.jsx';
+import LoginPage from './pages/Login.jsx';
+import DashboardPage from './pages/Dashboard.jsx';
+import ItemsPage from './pages/items/ItemsPage.jsx';
+import MovementRequestsPage from './pages/movements/MovementRequestsPage.jsx';
+import ApprovalsPage from './pages/movements/ApprovalsPage.jsx';
+import CustomersPage from './pages/customers/CustomersPage.jsx';
+import ReportsPage from './pages/reports/ReportsPage.jsx';
+import AuditLogsPage from './pages/audit/AuditLogsPage.jsx';
+import UsersPage from './pages/users/UsersPage.jsx';
+
+export default function App() {
+  return (
+    <Routes>
+      <Route path="/login" element={<LoginPage />} />
+      <Route
+        path="/"
+        element={
+          <ProtectedRoute>
+            <AppLayout />
+          </ProtectedRoute>
+        }
+      >
+        <Route index element={<DashboardPage />} />
+        <Route path="items" element={<ItemsPage />} />
+        <Route path="requests" element={<MovementRequestsPage />} />
+        <Route path="approvals" element={<ApprovalsPage />} />
+        <Route path="customers" element={<CustomersPage />} />
+        <Route path="reports" element={<ReportsPage />} />
+        <Route path="audit" element={<AuditLogsPage />} />
+        <Route path="users" element={<UsersPage />} />
+      </Route>
+      <Route path="*" element={<Navigate to="/" replace />} />
+    </Routes>
+  );
+}

--- a/frontend/src/components/AppLayout.jsx
+++ b/frontend/src/components/AppLayout.jsx
@@ -1,0 +1,17 @@
+import { Outlet } from 'react-router-dom';
+import Sidebar from './Sidebar.jsx';
+import Header from './Header.jsx';
+
+export default function AppLayout() {
+  return (
+    <div className="app-layout">
+      <Sidebar />
+      <div className="main-content">
+        <Header />
+        <div className="page-wrapper">
+          <Outlet />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/ErrorMessage.jsx
+++ b/frontend/src/components/ErrorMessage.jsx
@@ -1,0 +1,7 @@
+export default function ErrorMessage({ error }) {
+  if (!error) {
+    return null;
+  }
+  const message = typeof error === 'string' ? error : error.message || 'Ocurrió un error inesperado.';
+  return <div className="error-message">{message}</div>;
+}

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -1,0 +1,25 @@
+import { useAuth } from '../context/AuthContext.jsx';
+
+export default function Header() {
+  const { user, logout } = useAuth();
+
+  return (
+    <header className="app-header">
+      <h1>Gestión de Stock</h1>
+      <div className="header-user">
+        {user ? (
+          <>
+            <span>
+              {user.username} · {user.role || 'Sin rol'}
+            </span>
+            <button type="button" className="secondary-button" onClick={logout}>
+              Cerrar sesión
+            </button>
+          </>
+        ) : (
+          <span>Sin sesión activa</span>
+        )}
+      </div>
+    </header>
+  );
+}

--- a/frontend/src/components/LoadingIndicator.jsx
+++ b/frontend/src/components/LoadingIndicator.jsx
@@ -1,0 +1,3 @@
+export default function LoadingIndicator({ message = 'Cargando información...' }) {
+  return <div className="page-loading">{message}</div>;
+}

--- a/frontend/src/components/ProtectedRoute.jsx
+++ b/frontend/src/components/ProtectedRoute.jsx
@@ -1,0 +1,16 @@
+import { Navigate } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext.jsx';
+
+export default function ProtectedRoute({ children }) {
+  const { user, initializing } = useAuth();
+
+  if (initializing) {
+    return <div className="page-loading">Preparando aplicación...</div>;
+  }
+
+  if (!user) {
+    return <Navigate to="/login" replace />;
+  }
+
+  return children;
+}

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -1,0 +1,32 @@
+import { NavLink } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext.jsx';
+
+const NAV_ITEMS = [
+  { to: '/', label: 'Resumen' },
+  { to: '/items', label: 'Artículos', permission: 'items.read' },
+  { to: '/requests', label: 'Solicitudes', permission: 'stock.request' },
+  { to: '/approvals', label: 'Aprobaciones', permission: 'stock.approve' },
+  { to: '/customers', label: 'Clientes', permission: 'items.read' },
+  { to: '/reports', label: 'Reportes', permission: 'reports.read' },
+  { to: '/audit', label: 'Auditoría', permission: 'stock.logs.read' },
+  { to: '/users', label: 'Usuarios', permission: 'users.read' }
+];
+
+export default function Sidebar() {
+  const { user } = useAuth();
+  const permissions = user?.permissions || [];
+
+  return (
+    <aside className="sidebar">
+      <div className="sidebar-header">Thibe Stock</div>
+      <nav className="sidebar-nav">
+        {NAV_ITEMS.filter(item => !item.permission || permissions.includes(item.permission)).map(item => (
+          <NavLink key={item.to} to={item.to} end={item.to === '/'}>
+            {item.label}
+          </NavLink>
+        ))}
+      </nav>
+      <div className="sidebar-footer">v1.0.0</div>
+    </aside>
+  );
+}

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -1,0 +1,264 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
+
+const API_BASE_URL = (import.meta.env.VITE_API_BASE_URL || 'http://localhost:3000/api').replace(/\/$/, '');
+const STORAGE_KEY = 'gestionthibe:auth';
+
+const AuthContext = createContext(null);
+
+function normalizePath(path) {
+  if (!path.startsWith('/')) {
+    return `/${path}`;
+  }
+  return path;
+}
+
+function parseStoredValue() {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (!stored) {
+      return { user: null, accessToken: null, refreshToken: null };
+    }
+    const parsed = JSON.parse(stored);
+    return {
+      user: parsed.user || null,
+      accessToken: parsed.accessToken || null,
+      refreshToken: parsed.refreshToken || null
+    };
+  } catch (error) {
+    console.warn('No se pudo leer el estado de autenticación persistido', error);
+    return { user: null, accessToken: null, refreshToken: null };
+  }
+}
+
+export function AuthProvider({ children }) {
+  const [state, setState] = useState(() => parseStoredValue());
+  const [initializing, setInitializing] = useState(true);
+  const refreshPromiseRef = useRef(null);
+  const stateRef = useRef(state);
+
+  useEffect(() => {
+    stateRef.current = state;
+  }, [state]);
+
+  const persistState = useCallback(nextState => {
+    if (nextState.accessToken && nextState.refreshToken && nextState.user) {
+      localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({
+          accessToken: nextState.accessToken,
+          refreshToken: nextState.refreshToken,
+          user: nextState.user
+        })
+      );
+    } else {
+      localStorage.removeItem(STORAGE_KEY);
+    }
+  }, []);
+
+  const clearState = useCallback(() => {
+    setState({ user: null, accessToken: null, refreshToken: null });
+    persistState({ user: null, accessToken: null, refreshToken: null });
+  }, [persistState]);
+
+  const refreshSession = useCallback(async () => {
+    const { refreshToken } = stateRef.current;
+    if (!refreshToken) {
+      return null;
+    }
+    if (!refreshPromiseRef.current) {
+      refreshPromiseRef.current = fetch(`${API_BASE_URL}/auth/refresh`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+        body: JSON.stringify({ refreshToken })
+      })
+        .then(async response => {
+          if (!response.ok) {
+            throw new Error('No se pudo refrescar la sesión');
+          }
+          const data = await response.json();
+          setState(prev => {
+            const next = {
+              ...prev,
+              user: data.user,
+              accessToken: data.accessToken
+            };
+            persistState({ ...next, refreshToken: prev.refreshToken });
+            return next;
+          });
+          return data;
+        })
+        .catch(error => {
+          clearState();
+          throw error;
+        })
+        .finally(() => {
+          refreshPromiseRef.current = null;
+        });
+    }
+    return refreshPromiseRef.current;
+  }, [clearState, persistState]);
+
+  useEffect(() => {
+    let isMounted = true;
+    const bootstrap = async () => {
+      try {
+        if (stateRef.current.refreshToken && stateRef.current.accessToken) {
+          await refreshSession();
+        }
+      } catch (error) {
+        if (isMounted) {
+          console.warn('Sesión inválida, se requiere autenticación nuevamente.');
+        }
+      } finally {
+        if (isMounted) {
+          setInitializing(false);
+        }
+      }
+    };
+    bootstrap();
+    return () => {
+      isMounted = false;
+    };
+  }, [refreshSession]);
+
+  const login = useCallback(
+    async (email, password) => {
+      const response = await fetch(`${API_BASE_URL}/auth/login`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+        body: JSON.stringify({ email, password })
+      });
+      const data = await response.json().catch(() => null);
+      if (!response.ok) {
+        const message = data?.message || 'No se pudo iniciar sesión';
+        throw new Error(message);
+      }
+      const nextState = {
+        user: data.user,
+        accessToken: data.accessToken,
+        refreshToken: data.refreshToken
+      };
+      setState(nextState);
+      persistState(nextState);
+      return data.user;
+    },
+    [persistState]
+  );
+
+  const logout = useCallback(async () => {
+    const { refreshToken } = stateRef.current;
+    try {
+      if (refreshToken) {
+        await fetch(`${API_BASE_URL}/auth/logout`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ refreshToken })
+        });
+      }
+    } catch (error) {
+      console.warn('No se pudo cerrar sesión correctamente', error);
+    } finally {
+      clearState();
+    }
+  }, [clearState]);
+
+  const authFetch = useCallback(
+    async (path, { method = 'GET', body, query, headers = {}, skipAuth = false } = {}) => {
+      const url = new URL(`${API_BASE_URL}${normalizePath(path)}`);
+      if (query) {
+        Object.entries(query)
+          .filter(([, value]) => value !== undefined && value !== null && value !== '')
+          .forEach(([key, value]) => url.searchParams.append(key, value));
+      }
+
+      const config = {
+        method,
+        headers: {
+          Accept: 'application/json',
+          ...headers
+        }
+      };
+
+      let isFormData = false;
+      if (body !== undefined && body !== null) {
+        if (body instanceof FormData) {
+          config.body = body;
+          isFormData = true;
+        } else {
+          config.body = JSON.stringify(body);
+          config.headers['Content-Type'] = 'application/json';
+        }
+      }
+
+      if (!skipAuth) {
+        const { accessToken } = stateRef.current;
+        if (accessToken) {
+          config.headers.Authorization = `Bearer ${accessToken}`;
+        }
+      }
+
+      let response = await fetch(url, config);
+
+      if (response.status === 401 && !skipAuth && stateRef.current.refreshToken) {
+        try {
+          await refreshSession();
+        } catch (error) {
+          throw new Error('Sesión expirada. Inicie sesión nuevamente.');
+        }
+        const { accessToken } = stateRef.current;
+        if (accessToken) {
+          const retryConfig = {
+            ...config,
+            headers: { ...config.headers, Authorization: `Bearer ${accessToken}` }
+          };
+          if (!isFormData && body !== undefined && body !== null && !(body instanceof FormData)) {
+            retryConfig.body = JSON.stringify(body);
+          }
+          response = await fetch(url, retryConfig);
+        }
+      }
+
+      const contentType = response.headers.get('content-type') || '';
+      let data = null;
+      if (contentType.includes('application/json')) {
+        data = await response.json().catch(() => null);
+      } else if (contentType.startsWith('text/')) {
+        data = await response.text();
+      }
+
+      if (!response.ok) {
+        const message = data?.message || (typeof data === 'string' ? data : 'Error en la solicitud');
+        const error = new Error(message);
+        error.status = response.status;
+        error.details = data;
+        throw error;
+      }
+
+      return data;
+    },
+    [refreshSession]
+  );
+
+  const value = useMemo(
+    () => ({
+      user: state.user,
+      accessToken: state.accessToken,
+      refreshToken: state.refreshToken,
+      initializing,
+      login,
+      logout,
+      authFetch
+    }),
+    [state.user, state.accessToken, state.refreshToken, initializing, login, logout, authFetch]
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+export function useAuth() {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('useAuth debe utilizarse dentro de un AuthProvider');
+  }
+  return context;
+}

--- a/frontend/src/hooks/useApi.js
+++ b/frontend/src/hooks/useApi.js
@@ -1,0 +1,17 @@
+import { useMemo } from 'react';
+import { useAuth } from '../context/AuthContext.jsx';
+
+export default function useApi() {
+  const { authFetch } = useAuth();
+
+  return useMemo(
+    () => ({
+      get: (path, options) => authFetch(path, { ...options, method: 'GET' }),
+      post: (path, body, options) => authFetch(path, { ...options, method: 'POST', body }),
+      put: (path, body, options) => authFetch(path, { ...options, method: 'PUT', body }),
+      patch: (path, body, options) => authFetch(path, { ...options, method: 'PATCH', body }),
+      delete: (path, options) => authFetch(path, { ...options, method: 'DELETE' })
+    }),
+    [authFetch]
+  );
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,330 @@
+:root {
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  color: #0f172a;
+  background-color: #f8fafc;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background-color: #f8fafc;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+button {
+  font-family: inherit;
+}
+
+input,
+select,
+textarea,
+button {
+  border-radius: 6px;
+  border: 1px solid #cbd5f5;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.95rem;
+}
+
+button {
+  background-color: #2563eb;
+  color: #fff;
+  border: none;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+button:hover:not(:disabled) {
+  background-color: #1d4ed8;
+}
+
+.app-layout {
+  display: grid;
+  grid-template-columns: 240px 1fr;
+  min-height: 100vh;
+}
+
+.sidebar {
+  background-color: #0f172a;
+  color: #e2e8f0;
+  display: flex;
+  flex-direction: column;
+  padding: 1.5rem 1rem;
+}
+
+.sidebar-header {
+  font-size: 1.4rem;
+  font-weight: 600;
+  margin-bottom: 2rem;
+  color: #fff;
+}
+
+.sidebar-nav {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  flex: 1;
+}
+
+.sidebar-nav a {
+  padding: 0.6rem 0.75rem;
+  border-radius: 8px;
+  color: #cbd5f5;
+  font-weight: 500;
+}
+
+.sidebar-nav a.active,
+.sidebar-nav a:hover {
+  background-color: rgba(59, 130, 246, 0.18);
+  color: #fff;
+}
+
+.sidebar-footer {
+  margin-top: auto;
+  font-size: 0.85rem;
+  color: #94a3b8;
+}
+
+.main-content {
+  background-color: #f8fafc;
+  display: flex;
+  flex-direction: column;
+}
+
+.app-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 1.5rem;
+  background-color: #fff;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.app-header h1 {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+.header-user {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+
+.header-user span {
+  font-size: 0.95rem;
+  color: #475569;
+}
+
+.page-wrapper {
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.section-card {
+  background-color: #fff;
+  padding: 1.5rem;
+  border-radius: 12px;
+  border: 1px solid #e2e8f0;
+  box-shadow: 0 10px 25px -20px rgba(15, 23, 42, 0.45);
+}
+
+.section-card h2 {
+  margin-top: 0;
+  margin-bottom: 1rem;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+}
+
+.table-wrapper {
+  overflow-x: auto;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+}
+
+thead {
+  background-color: #e2e8f0;
+}
+
+th,
+td {
+  padding: 0.6rem 0.75rem;
+  text-align: left;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+th {
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.03em;
+  color: #475569;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.1rem 0.5rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: capitalize;
+  color: #1e293b;
+  background-color: #e0f2fe;
+}
+
+.badge.pending {
+  background-color: #fef3c7;
+  color: #92400e;
+}
+
+.badge.approved {
+  background-color: #dcfce7;
+  color: #166534;
+}
+
+.badge.rejected {
+  background-color: #fee2e2;
+  color: #b91c1c;
+}
+
+.inline-actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.secondary-button {
+  background-color: transparent;
+  color: #2563eb;
+  border: 1px solid #2563eb;
+}
+
+.secondary-button:hover:not(:disabled) {
+  background-color: rgba(37, 99, 235, 0.12);
+}
+
+.input-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.input-group label {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: #475569;
+}
+
+.error-message {
+  padding: 0.8rem 1rem;
+  border-radius: 8px;
+  background-color: #fee2e2;
+  color: #b91c1c;
+  border: 1px solid #fecaca;
+}
+
+.success-message {
+  padding: 0.8rem 1rem;
+  border-radius: 8px;
+  background-color: #dcfce7;
+  color: #166534;
+  border: 1px solid #bbf7d0;
+}
+
+.page-loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 60vh;
+  color: #475569;
+}
+
+.metrics-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.metric-card {
+  background-color: #fff;
+  border-radius: 12px;
+  padding: 1.2rem;
+  border: 1px solid #e2e8f0;
+  box-shadow: 0 10px 25px -20px rgba(15, 23, 42, 0.45);
+}
+
+.metric-card h3 {
+  margin: 0 0 0.4rem 0;
+  font-size: 0.95rem;
+  color: #475569;
+}
+
+.metric-card p {
+  margin: 0;
+  font-size: 1.6rem;
+  font-weight: 700;
+}
+
+.flex-between {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.chip-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+@media (max-width: 900px) {
+  .app-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar {
+    flex-direction: row;
+    align-items: center;
+    gap: 1rem;
+    padding: 1rem;
+    overflow-x: auto;
+  }
+
+  .sidebar-header {
+    margin: 0;
+  }
+
+  .sidebar-nav {
+    flex-direction: row;
+    align-items: center;
+  }
+
+  .sidebar-footer {
+    display: none;
+  }
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App.jsx';
+import { AuthProvider } from './context/AuthContext.jsx';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <AuthProvider>
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </AuthProvider>
+  </React.StrictMode>
+);

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -1,0 +1,200 @@
+import { useEffect, useMemo, useState } from 'react';
+import useApi from '../hooks/useApi.js';
+import { useAuth } from '../context/AuthContext.jsx';
+import LoadingIndicator from '../components/LoadingIndicator.jsx';
+import ErrorMessage from '../components/ErrorMessage.jsx';
+
+export default function DashboardPage() {
+  const api = useApi();
+  const { user } = useAuth();
+  const permissions = useMemo(() => user?.permissions || [], [user]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [stockData, setStockData] = useState([]);
+  const [pendingRequests, setPendingRequests] = useState([]);
+  const [customers, setCustomers] = useState([]);
+
+  const canViewReports = permissions.includes('reports.read');
+  const canManageRequests = permissions.includes('stock.request') || permissions.includes('stock.approve');
+  const canViewCustomers = permissions.includes('items.read');
+
+  useEffect(() => {
+    let isMounted = true;
+    const load = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        let stockResponse = [];
+        if (canViewReports) {
+          stockResponse = await api.get('/reports/stock');
+        }
+        let pendingResponse = [];
+        if (canManageRequests) {
+          pendingResponse = await api.get('/stock/requests', {
+            query: permissions.includes('stock.approve') ? { status: 'pending' } : undefined
+          });
+        }
+        let customersResponse = [];
+        if (canViewCustomers) {
+          customersResponse = await api.get('/customers');
+        }
+        if (!isMounted) return;
+        setStockData(Array.isArray(stockResponse) ? stockResponse : []);
+        setPendingRequests(Array.isArray(pendingResponse) ? pendingResponse : []);
+        setCustomers(Array.isArray(customersResponse) ? customersResponse : []);
+      } catch (err) {
+        if (!isMounted) return;
+        setError(err);
+      } finally {
+        if (isMounted) {
+          setLoading(false);
+        }
+      }
+    };
+    load();
+    return () => {
+      isMounted = false;
+    };
+  }, [api, canManageRequests, canViewCustomers, canViewReports, permissions]);
+
+  const metrics = useMemo(() => {
+    const totals = {
+      items: stockData.length,
+      general: 0,
+      overstock: 0,
+      customers: customers.length,
+      pending: pendingRequests.filter(request => request.status === 'pending').length
+    };
+    stockData.forEach(item => {
+      const stock = item.stock || {};
+      totals.general += Number(stock.general || 0);
+      totals.overstock += Number(stock.overstockGeneral || 0) + Number(stock.overstockThibe || 0) + Number(stock.overstockArenal || 0);
+    });
+    return totals;
+  }, [customers.length, pendingRequests, stockData]);
+
+  const topGroups = useMemo(() => {
+    const accumulator = new Map();
+    stockData.forEach(item => {
+      const groupName = item.group?.name || 'Sin grupo asignado';
+      const previous = accumulator.get(groupName) || 0;
+      accumulator.set(groupName, previous + Number(item.stock?.general || 0));
+    });
+    return Array.from(accumulator.entries())
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 5);
+  }, [stockData]);
+
+  if (loading) {
+    return <LoadingIndicator message="Calculando métricas..." />;
+  }
+
+  return (
+    <div className="dashboard-page">
+      <h2>Resumen operativo</h2>
+      <p style={{ color: '#475569', marginTop: '-0.5rem' }}>
+        Visualice los indicadores clave del inventario, solicitudes y clientes en un solo lugar.
+      </p>
+
+      {error && <ErrorMessage error={error} />}
+
+      <div className="metrics-grid">
+        <div className="metric-card">
+          <h3>Artículos activos</h3>
+          <p>{metrics.items}</p>
+          <span style={{ fontSize: '0.8rem', color: '#64748b' }}>Registros totales disponibles</span>
+        </div>
+        <div className="metric-card">
+          <h3>Stock general</h3>
+          <p>{metrics.general.toLocaleString('es-AR')}</p>
+          <span style={{ fontSize: '0.8rem', color: '#64748b' }}>Unidades en depósito principal</span>
+        </div>
+        <div className="metric-card">
+          <h3>Sobrestock</h3>
+          <p>{metrics.overstock.toLocaleString('es-AR')}</p>
+          <span style={{ fontSize: '0.8rem', color: '#64748b' }}>General + Thibe + Arenal Import</span>
+        </div>
+        <div className="metric-card">
+          <h3>Clientes con stock reservado</h3>
+          <p>{metrics.customers}</p>
+          <span style={{ fontSize: '0.8rem', color: '#64748b' }}>Clientes activos registrados</span>
+        </div>
+        <div className="metric-card">
+          <h3>Solicitudes pendientes</h3>
+          <p>{metrics.pending}</p>
+          <span style={{ fontSize: '0.8rem', color: '#64748b' }}>Movimientos a aprobar</span>
+        </div>
+      </div>
+
+      {topGroups.length > 0 && (
+        <div className="section-card">
+          <div className="flex-between">
+            <h2>Top 5 grupos por stock general</h2>
+            <span style={{ color: '#64748b', fontSize: '0.85rem' }}>Basado en unidades disponibles</span>
+          </div>
+          <div className="table-wrapper">
+            <table>
+              <thead>
+                <tr>
+                  <th>Grupo</th>
+                  <th>Stock General</th>
+                </tr>
+              </thead>
+              <tbody>
+                {topGroups.map(([group, quantity]) => (
+                  <tr key={group}>
+                    <td>{group}</td>
+                    <td>{quantity.toLocaleString('es-AR')}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+
+      {pendingRequests.length > 0 && (
+        <div className="section-card">
+          <div className="flex-between">
+            <h2>Últimas solicitudes registradas</h2>
+            <span style={{ color: '#64748b', fontSize: '0.85rem' }}>
+              {pendingRequests.length > 5 ? 'Mostrando 5 más recientes' : `${pendingRequests.length} solicitudes`}
+            </span>
+          </div>
+          <div className="table-wrapper">
+            <table>
+              <thead>
+                <tr>
+                  <th>Código</th>
+                  <th>Tipo</th>
+                  <th>De</th>
+                  <th>A</th>
+                  <th>Cantidad</th>
+                  <th>Estado</th>
+                  <th>Solicitado por</th>
+                  <th>Fecha</th>
+                </tr>
+              </thead>
+              <tbody>
+                {pendingRequests.slice(0, 5).map(request => (
+                  <tr key={request.id}>
+                    <td>{request.item?.code || request.itemId}</td>
+                    <td className="badge pending">{request.type}</td>
+                    <td>{request.fromList || '-'}</td>
+                    <td>{request.toList || '-'}</td>
+                    <td>{request.quantity}</td>
+                    <td>
+                      <span className={`badge ${request.status}`}>{request.status}</span>
+                    </td>
+                    <td>{request.requestedBy?.username || 'N/D'}</td>
+                    <td>{new Date(request.requestedAt).toLocaleString('es-AR')}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -1,0 +1,69 @@
+import { useState } from 'react';
+import { Navigate, useNavigate } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext.jsx';
+
+export default function LoginPage() {
+  const navigate = useNavigate();
+  const { login, user, initializing } = useAuth();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState(null);
+  const [loading, setLoading] = useState(false);
+
+  if (!initializing && user) {
+    return <Navigate to="/" replace />;
+  }
+
+  const handleSubmit = async event => {
+    event.preventDefault();
+    setError(null);
+    setLoading(true);
+    try {
+      await login(email, password);
+      navigate('/', { replace: true });
+    } catch (err) {
+      setError(err.message || 'No se pudo iniciar sesión.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="page-loading" style={{ flexDirection: 'column', gap: '1.5rem' }}>
+      <div className="section-card" style={{ width: 'min(420px, 90vw)' }}>
+        <h2>Ingreso al sistema</h2>
+        <p style={{ color: '#475569', fontSize: '0.95rem' }}>
+          Utilice sus credenciales corporativas para acceder al panel de gestión de stock.
+        </p>
+        {error && <div className="error-message">{error}</div>}
+        <form onSubmit={handleSubmit} className="form-grid" style={{ gridTemplateColumns: '1fr' }}>
+          <div className="input-group">
+            <label htmlFor="email">Email</label>
+            <input
+              id="email"
+              type="email"
+              value={email}
+              onChange={event => setEmail(event.target.value)}
+              required
+              placeholder="nombre@thibe.com"
+            />
+          </div>
+          <div className="input-group">
+            <label htmlFor="password">Contraseña</label>
+            <input
+              id="password"
+              type="password"
+              value={password}
+              onChange={event => setPassword(event.target.value)}
+              required
+              placeholder="••••••••"
+            />
+          </div>
+          <button type="submit" disabled={loading}>
+            {loading ? 'Ingresando...' : 'Ingresar'}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/audit/AuditLogsPage.jsx
+++ b/frontend/src/pages/audit/AuditLogsPage.jsx
@@ -1,0 +1,130 @@
+import { useEffect, useMemo, useState } from 'react';
+import useApi from '../../hooks/useApi.js';
+import { useAuth } from '../../context/AuthContext.jsx';
+import LoadingIndicator from '../../components/LoadingIndicator.jsx';
+import ErrorMessage from '../../components/ErrorMessage.jsx';
+
+export default function AuditLogsPage() {
+  const api = useApi();
+  const { user } = useAuth();
+  const permissions = useMemo(() => user?.permissions || [], [user]);
+  const canViewLogs = permissions.includes('stock.logs.read');
+
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [logs, setLogs] = useState([]);
+  const [filters, setFilters] = useState({ requestId: '', limit: 100 });
+
+  useEffect(() => {
+    let active = true;
+    const loadLogs = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const response = await api.get('/logs/movements', {
+          query: {
+            requestId: filters.requestId || undefined,
+            limit: filters.limit
+          }
+        });
+        if (!active) return;
+        setLogs(Array.isArray(response) ? response : []);
+      } catch (err) {
+        if (!active) return;
+        setError(err);
+      } finally {
+        if (active) {
+          setLoading(false);
+        }
+      }
+    };
+    if (canViewLogs) {
+      loadLogs();
+    }
+    return () => {
+      active = false;
+    };
+  }, [api, canViewLogs, filters.limit, filters.requestId]);
+
+  if (!canViewLogs) {
+    return <ErrorMessage error="No tiene permisos para acceder a la auditoría." />;
+  }
+
+  return (
+    <div>
+      <h2>Auditoría de movimientos</h2>
+      <p style={{ color: '#475569', marginTop: '-0.4rem' }}>
+        Consulte el historial de acciones registradas sobre solicitudes de movimiento y operaciones críticas.
+      </p>
+
+      {error && <ErrorMessage error={error} />}
+
+      <div className="section-card">
+        <form className="form-grid" style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))' }}>
+          <div className="input-group">
+            <label htmlFor="requestId">ID de solicitud</label>
+            <input
+              id="requestId"
+              value={filters.requestId}
+              onChange={event => setFilters(prev => ({ ...prev, requestId: event.target.value }))}
+              placeholder="UUID de la solicitud"
+            />
+          </div>
+          <div className="input-group">
+            <label htmlFor="limit">Límite</label>
+            <input
+              id="limit"
+              type="number"
+              min="10"
+              max="500"
+              value={filters.limit}
+              onChange={event => setFilters(prev => ({ ...prev, limit: Number(event.target.value) }))}
+            />
+          </div>
+        </form>
+      </div>
+
+      <div className="section-card">
+        {loading ? (
+          <LoadingIndicator message="Obteniendo registros de auditoría..." />
+        ) : (
+          <div className="table-wrapper" style={{ marginTop: '1rem' }}>
+            <table>
+              <thead>
+                <tr>
+                  <th>Fecha</th>
+                  <th>Acción</th>
+                  <th>Solicitud</th>
+                  <th>Usuario</th>
+                  <th>IP</th>
+                  <th>User Agent</th>
+                  <th>Notas</th>
+                </tr>
+              </thead>
+              <tbody>
+                {logs.map(log => (
+                  <tr key={log.id}>
+                    <td>{new Date(log.timestamp).toLocaleString('es-AR')}</td>
+                    <td>{log.action}</td>
+                    <td>{log.movementRequestId || '-'}</td>
+                    <td>{log.actor?.username || log.actor?.email || '-'}</td>
+                    <td>{log.metadata?.ip || '-'}</td>
+                    <td>{log.metadata?.userAgent || '-'}</td>
+                    <td>{log.metadata?.notes || '-'}</td>
+                  </tr>
+                ))}
+                {logs.length === 0 && (
+                  <tr>
+                    <td colSpan={7} style={{ textAlign: 'center', padding: '1.5rem 0' }}>
+                      No se encontraron registros.
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/customers/CustomersPage.jsx
+++ b/frontend/src/pages/customers/CustomersPage.jsx
@@ -1,0 +1,258 @@
+import { useEffect, useMemo, useState } from 'react';
+import useApi from '../../hooks/useApi.js';
+import { useAuth } from '../../context/AuthContext.jsx';
+import LoadingIndicator from '../../components/LoadingIndicator.jsx';
+import ErrorMessage from '../../components/ErrorMessage.jsx';
+
+export default function CustomersPage() {
+  const api = useApi();
+  const { user } = useAuth();
+  const permissions = useMemo(() => user?.permissions || [], [user]);
+  const canWrite = permissions.includes('items.write');
+  const canViewReserved = permissions.includes('reports.read');
+
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [customers, setCustomers] = useState([]);
+  const [formValues, setFormValues] = useState({ name: '', contactInfo: '', status: 'active' });
+  const [saving, setSaving] = useState(false);
+  const [successMessage, setSuccessMessage] = useState('');
+  const [selectedCustomer, setSelectedCustomer] = useState(null);
+  const [customerStock, setCustomerStock] = useState([]);
+  const [loadingStock, setLoadingStock] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    const loadCustomers = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const response = await api.get('/customers');
+        if (!active) return;
+        setCustomers(Array.isArray(response) ? response : []);
+        if (response?.[0]) {
+          setSelectedCustomer(response[0]);
+        }
+      } catch (err) {
+        if (!active) return;
+        setError(err);
+      } finally {
+        if (active) {
+          setLoading(false);
+        }
+      }
+    };
+    loadCustomers();
+    return () => {
+      active = false;
+    };
+  }, [api]);
+
+  useEffect(() => {
+    let active = true;
+    const loadReserved = async customerId => {
+      if (!customerId || !canViewReserved) {
+        setCustomerStock([]);
+        return;
+      }
+      setLoadingStock(true);
+      try {
+        const response = await api.get(`/customers/${customerId}/stock`);
+        if (!active) return;
+        setCustomerStock(Array.isArray(response) ? response : []);
+      } catch (err) {
+        if (!active) return;
+        console.warn('No se pudo obtener el stock reservado', err);
+        setCustomerStock([]);
+      } finally {
+        if (active) {
+          setLoadingStock(false);
+        }
+      }
+    };
+    loadReserved(selectedCustomer?.id);
+    return () => {
+      active = false;
+    };
+  }, [api, canViewReserved, selectedCustomer?.id]);
+
+  const handleFormChange = event => {
+    const { name, value } = event.target;
+    setFormValues(prev => ({ ...prev, [name]: value }));
+  };
+
+  const handleEdit = customer => {
+    setSelectedCustomer(customer);
+    setFormValues({
+      name: customer.name,
+      contactInfo: customer.contactInfo || '',
+      status: customer.status || 'active'
+    });
+  };
+
+  const handleSubmit = async event => {
+    event.preventDefault();
+    if (!canWrite) return;
+    setSaving(true);
+    setError(null);
+    try {
+      if (selectedCustomer && customers.some(customer => customer.id === selectedCustomer.id)) {
+        const updated = await api.put(`/customers/${selectedCustomer.id}`, formValues);
+        setCustomers(prev => prev.map(customer => (customer.id === updated.id ? updated : customer)));
+        setSuccessMessage(`Cliente ${updated.name} actualizado.`);
+      } else {
+        const created = await api.post('/customers', formValues);
+        setCustomers(prev => [created, ...prev]);
+        setSelectedCustomer(created);
+        setSuccessMessage(`Cliente ${created.name} creado.`);
+      }
+    } catch (err) {
+      setError(err);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) {
+    return <LoadingIndicator message="Cargando clientes..." />;
+  }
+
+  return (
+    <div>
+      <h2>Clientes y reservas</h2>
+      <p style={{ color: '#475569', marginTop: '-0.4rem' }}>
+        Administre clientes y visualice el stock reservado asociado a cada uno.
+      </p>
+
+      {error && <ErrorMessage error={error} />}
+      {successMessage && <div className="success-message">{successMessage}</div>}
+
+      <div className="section-card">
+        <div className="flex-between">
+          <h3>Clientes registrados</h3>
+          <span className="badge">{customers.length} clientes</span>
+        </div>
+        <div className="table-wrapper" style={{ marginTop: '1rem' }}>
+          <table>
+            <thead>
+              <tr>
+                <th>Nombre</th>
+                <th>Contacto</th>
+                <th>Estado</th>
+                {canWrite && <th>Acciones</th>}
+              </tr>
+            </thead>
+            <tbody>
+              {customers.map(customer => (
+                <tr
+                  key={customer.id}
+                  onClick={() => setSelectedCustomer(customer)}
+                  style={{ backgroundColor: selectedCustomer?.id === customer.id ? '#e2e8f0' : undefined, cursor: 'pointer' }}
+                >
+                  <td>{customer.name}</td>
+                  <td>{customer.contactInfo || '-'}</td>
+                  <td>
+                    <span className={`badge ${customer.status === 'active' ? 'approved' : 'rejected'}`}>
+                      {customer.status}
+                    </span>
+                  </td>
+                  {canWrite && (
+                    <td>
+                      <button type="button" className="secondary-button" onClick={() => handleEdit(customer)}>
+                        Editar
+                      </button>
+                    </td>
+                  )}
+                </tr>
+              ))}
+              {customers.length === 0 && (
+                <tr>
+                  <td colSpan={canWrite ? 4 : 3} style={{ textAlign: 'center', padding: '1.5rem 0' }}>
+                    No hay clientes registrados.
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      {canWrite && (
+        <div className="section-card">
+          <h3>{selectedCustomer ? 'Editar cliente' : 'Nuevo cliente'}</h3>
+          <form className="form-grid" style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))' }} onSubmit={handleSubmit}>
+            <div className="input-group">
+              <label htmlFor="customerName">Nombre *</label>
+              <input
+                id="customerName"
+                name="name"
+                value={formValues.name}
+                onChange={handleFormChange}
+                required
+              />
+            </div>
+            <div className="input-group">
+              <label htmlFor="customerContact">Contacto</label>
+              <input
+                id="customerContact"
+                name="contactInfo"
+                value={formValues.contactInfo}
+                onChange={handleFormChange}
+              />
+            </div>
+            <div className="input-group">
+              <label htmlFor="customerStatus">Estado</label>
+              <select id="customerStatus" name="status" value={formValues.status} onChange={handleFormChange}>
+                <option value="active">Activo</option>
+                <option value="inactive">Inactivo</option>
+              </select>
+            </div>
+            <div>
+              <button type="submit" disabled={saving}>
+                {saving ? 'Guardando...' : selectedCustomer ? 'Actualizar cliente' : 'Crear cliente'}
+              </button>
+            </div>
+          </form>
+        </div>
+      )}
+
+      <div className="section-card">
+        <h3>Stock reservado</h3>
+        {!canViewReserved ? (
+          <p style={{ color: '#64748b' }}>No tiene permisos para consultar stock reservado.</p>
+        ) : loadingStock ? (
+          <LoadingIndicator message="Consultando stock del cliente..." />
+        ) : customerStock.length === 0 ? (
+          <p style={{ color: '#64748b' }}>No hay stock reservado para el cliente seleccionado.</p>
+        ) : (
+          <div className="table-wrapper" style={{ marginTop: '1rem' }}>
+            <table>
+              <thead>
+                <tr>
+                  <th>Artículo</th>
+                  <th>Código</th>
+                  <th>Cantidad</th>
+                  <th>Estado</th>
+                  <th>Reservado</th>
+                  <th>Entregado</th>
+                </tr>
+              </thead>
+              <tbody>
+                {customerStock.map(record => (
+                  <tr key={record.id}>
+                    <td>{record.item?.description || '-'}</td>
+                    <td>{record.item?.code || record.itemId}</td>
+                    <td>{record.quantity}</td>
+                    <td>{record.status}</td>
+                    <td>{new Date(record.dateCreated).toLocaleDateString('es-AR')}</td>
+                    <td>{record.dateDelivered ? new Date(record.dateDelivered).toLocaleDateString('es-AR') : '-'}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/items/ItemsPage.jsx
+++ b/frontend/src/pages/items/ItemsPage.jsx
@@ -1,0 +1,469 @@
+import { useEffect, useMemo, useState } from 'react';
+import useApi from '../../hooks/useApi.js';
+import { useAuth } from '../../context/AuthContext.jsx';
+import LoadingIndicator from '../../components/LoadingIndicator.jsx';
+import ErrorMessage from '../../components/ErrorMessage.jsx';
+
+const ATTRIBUTES = ['gender', 'size', 'color', 'material', 'season', 'fit'];
+
+export default function ItemsPage() {
+  const api = useApi();
+  const { user } = useAuth();
+  const permissions = useMemo(() => user?.permissions || [], [user]);
+  const canWrite = permissions.includes('items.write');
+
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [items, setItems] = useState([]);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(1);
+  const [pageSize] = useState(20);
+  const [groups, setGroups] = useState([]);
+  const [filters, setFilters] = useState({ search: '', groupId: '', gender: '', size: '', color: '' });
+  const [formValues, setFormValues] = useState({
+    code: '',
+    description: '',
+    groupId: '',
+    gender: '',
+    size: '',
+    color: '',
+    material: '',
+    season: '',
+    fit: '',
+    stockGeneral: '',
+    overstockGeneral: '',
+    overstockThibe: '',
+    overstockArenal: ''
+  });
+  const [saving, setSaving] = useState(false);
+  const [successMessage, setSuccessMessage] = useState('');
+  const [editingItem, setEditingItem] = useState(null);
+
+  useEffect(() => {
+    let active = true;
+    const loadGroups = async () => {
+      try {
+        const response = await api.get('/groups');
+        if (active) {
+          setGroups(Array.isArray(response) ? response : []);
+        }
+      } catch (err) {
+        console.warn('No se pudieron cargar los grupos', err);
+      }
+    };
+    loadGroups();
+    return () => {
+      active = false;
+    };
+  }, [api]);
+
+  useEffect(() => {
+    let active = true;
+    const loadItems = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const query = {
+          page,
+          pageSize,
+          search: filters.search,
+          groupId: filters.groupId,
+          gender: filters.gender,
+          size: filters.size,
+          color: filters.color
+        };
+        const response = await api.get('/items', { query });
+        if (!active) return;
+        setItems(response.items || []);
+        setTotal(response.total || 0);
+      } catch (err) {
+        if (active) {
+          setError(err);
+        }
+      } finally {
+        if (active) {
+          setLoading(false);
+        }
+      }
+    };
+    loadItems();
+    return () => {
+      active = false;
+    };
+  }, [api, filters.color, filters.gender, filters.groupId, filters.search, filters.size, page, pageSize]);
+
+  const totalPages = Math.max(1, Math.ceil(total / pageSize));
+
+  const resetForm = () => {
+    setFormValues({
+      code: '',
+      description: '',
+      groupId: '',
+      gender: '',
+      size: '',
+      color: '',
+      material: '',
+      season: '',
+      fit: '',
+      stockGeneral: '',
+      overstockGeneral: '',
+      overstockThibe: '',
+      overstockArenal: ''
+    });
+    setEditingItem(null);
+  };
+
+  const handleFormChange = event => {
+    const { name, value } = event.target;
+    setFormValues(prev => ({ ...prev, [name]: value }));
+  };
+
+  const buildPayload = () => {
+    const stock = {
+      general: formValues.stockGeneral === '' ? undefined : Number(formValues.stockGeneral),
+      overstockGeneral:
+        formValues.overstockGeneral === '' ? undefined : Number(formValues.overstockGeneral),
+      overstockThibe: formValues.overstockThibe === '' ? undefined : Number(formValues.overstockThibe),
+      overstockArenal:
+        formValues.overstockArenal === '' ? undefined : Number(formValues.overstockArenal)
+    };
+    const attributes = {};
+    ATTRIBUTES.forEach(attribute => {
+      if (formValues[attribute]) {
+        attributes[attribute] = formValues[attribute];
+      }
+    });
+    return {
+      description: formValues.description,
+      groupId: formValues.groupId || null,
+      attributes: Object.keys(attributes).length ? attributes : undefined,
+      stock
+    };
+  };
+
+  const handleSubmit = async event => {
+    event.preventDefault();
+    if (!canWrite) return;
+    setSaving(true);
+    setError(null);
+    try {
+      if (editingItem) {
+        await api.put(`/items/${editingItem.id}`, buildPayload());
+        setSuccessMessage(`Artículo ${editingItem.code} actualizado correctamente.`);
+      } else {
+        const payload = buildPayload();
+        payload.code = formValues.code;
+        const response = await api.post('/items', payload);
+        setSuccessMessage(`Artículo ${response.code} creado correctamente.`);
+      }
+      resetForm();
+      setPage(1);
+      const refreshed = await api.get('/items', {
+        query: { ...filters, page: 1, pageSize }
+      });
+      setItems(refreshed.items || []);
+      setTotal(refreshed.total || 0);
+    } catch (err) {
+      setError(err);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleEdit = item => {
+    setEditingItem(item);
+    setFormValues({
+      code: item.code,
+      description: item.description,
+      groupId: item.groupId || '',
+      gender: item.attributes?.gender || '',
+      size: item.attributes?.size || '',
+      color: item.attributes?.color || '',
+      material: item.attributes?.material || '',
+      season: item.attributes?.season || '',
+      fit: item.attributes?.fit || '',
+      stockGeneral: item.stock?.general ?? '',
+      overstockGeneral: item.stock?.overstockGeneral ?? '',
+      overstockThibe: item.stock?.overstockThibe ?? '',
+      overstockArenal: item.stock?.overstockArenal ?? ''
+    });
+  };
+
+  return (
+    <div>
+      <div className="flex-between">
+        <div>
+          <h2>Gestión de artículos</h2>
+          <p style={{ color: '#475569', marginTop: '-0.4rem' }}>
+            Administre la taxonomía, atributos y stock por lista para cada artículo.
+          </p>
+        </div>
+        <div>
+          <span className="badge">Total: {total}</span>
+        </div>
+      </div>
+
+      {error && <ErrorMessage error={error} />}
+      {successMessage && <div className="success-message">{successMessage}</div>}
+
+      <div className="section-card">
+        <form className="form-grid" onSubmit={handleSubmit} style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))' }}>
+          {!editingItem && (
+            <div className="input-group">
+              <label htmlFor="code">Código *</label>
+              <input
+                id="code"
+                name="code"
+                value={formValues.code}
+                onChange={handleFormChange}
+                required
+                placeholder="SKU"
+                disabled={!!editingItem}
+              />
+            </div>
+          )}
+          <div className="input-group">
+            <label htmlFor="description">Descripción *</label>
+            <input
+              id="description"
+              name="description"
+              value={formValues.description}
+              onChange={handleFormChange}
+              required
+              placeholder="Descripción detallada"
+            />
+          </div>
+          <div className="input-group">
+            <label htmlFor="groupId">Grupo</label>
+            <select id="groupId" name="groupId" value={formValues.groupId} onChange={handleFormChange}>
+              <option value="">Sin asignar</option>
+              {groups.map(group => (
+                <option key={group.id} value={group.id}>
+                  {group.name}
+                </option>
+              ))}
+            </select>
+          </div>
+          {ATTRIBUTES.map(attribute => (
+            <div className="input-group" key={attribute}>
+              <label htmlFor={attribute}>{attribute.charAt(0).toUpperCase() + attribute.slice(1)}</label>
+              <input
+                id={attribute}
+                name={attribute}
+                value={formValues[attribute]}
+                onChange={handleFormChange}
+                placeholder={`Ingrese ${attribute}`}
+              />
+            </div>
+          ))}
+          <div className="input-group">
+            <label htmlFor="stockGeneral">Stock General</label>
+            <input
+              id="stockGeneral"
+              name="stockGeneral"
+              type="number"
+              min="0"
+              value={formValues.stockGeneral}
+              onChange={handleFormChange}
+            />
+          </div>
+          <div className="input-group">
+            <label htmlFor="overstockGeneral">Sobrestock General</label>
+            <input
+              id="overstockGeneral"
+              name="overstockGeneral"
+              type="number"
+              min="0"
+              value={formValues.overstockGeneral}
+              onChange={handleFormChange}
+            />
+          </div>
+          <div className="input-group">
+            <label htmlFor="overstockThibe">Sobrestock Thibe</label>
+            <input
+              id="overstockThibe"
+              name="overstockThibe"
+              type="number"
+              min="0"
+              value={formValues.overstockThibe}
+              onChange={handleFormChange}
+            />
+          </div>
+          <div className="input-group">
+            <label htmlFor="overstockArenal">Sobrestock Arenal</label>
+            <input
+              id="overstockArenal"
+              name="overstockArenal"
+              type="number"
+              min="0"
+              value={formValues.overstockArenal}
+              onChange={handleFormChange}
+            />
+          </div>
+          <div style={{ display: 'flex', alignItems: 'flex-end', gap: '0.5rem' }}>
+            <button type="submit" disabled={saving || !canWrite}>
+              {editingItem ? 'Actualizar artículo' : 'Crear artículo'}
+            </button>
+            {editingItem && (
+              <button type="button" className="secondary-button" onClick={resetForm}>
+                Cancelar
+              </button>
+            )}
+          </div>
+        </form>
+      </div>
+
+      <div className="section-card">
+        <h2>Buscar artículos</h2>
+        <form className="form-grid" style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))' }}>
+          <div className="input-group">
+            <label htmlFor="search">Buscar</label>
+            <input
+              id="search"
+              value={filters.search}
+              onChange={event => {
+                setFilters(prev => ({ ...prev, search: event.target.value }));
+                setPage(1);
+              }}
+              placeholder="Código o descripción"
+            />
+          </div>
+          <div className="input-group">
+            <label htmlFor="filterGroup">Grupo</label>
+            <select
+              id="filterGroup"
+              value={filters.groupId}
+              onChange={event => {
+                setFilters(prev => ({ ...prev, groupId: event.target.value }));
+                setPage(1);
+              }}
+            >
+              <option value="">Todos</option>
+              {groups.map(group => (
+                <option key={group.id} value={group.id}>
+                  {group.name}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="input-group">
+            <label htmlFor="filterGender">Género</label>
+            <input
+              id="filterGender"
+              value={filters.gender}
+              onChange={event => {
+                setFilters(prev => ({ ...prev, gender: event.target.value }));
+                setPage(1);
+              }}
+              placeholder="Dama, Caballero..."
+            />
+          </div>
+          <div className="input-group">
+            <label htmlFor="filterSize">Talle</label>
+            <input
+              id="filterSize"
+              value={filters.size}
+              onChange={event => {
+                setFilters(prev => ({ ...prev, size: event.target.value }));
+                setPage(1);
+              }}
+              placeholder="S, M, 36..."
+            />
+          </div>
+          <div className="input-group">
+            <label htmlFor="filterColor">Color</label>
+            <input
+              id="filterColor"
+              value={filters.color}
+              onChange={event => {
+                setFilters(prev => ({ ...prev, color: event.target.value }));
+                setPage(1);
+              }}
+              placeholder="Rojo, Azul..."
+            />
+          </div>
+        </form>
+
+        {loading ? (
+          <LoadingIndicator message="Cargando artículos..." />
+        ) : (
+          <div className="table-wrapper" style={{ marginTop: '1rem' }}>
+            <table>
+              <thead>
+                <tr>
+                  <th>Código</th>
+                  <th>Descripción</th>
+                  <th>Grupo</th>
+                  <th>Atributos</th>
+                  <th>General</th>
+                  <th>Sobre. General</th>
+                  <th>Sobre. Thibe</th>
+                  <th>Sobre. Arenal</th>
+                  {canWrite && <th>Acciones</th>}
+                </tr>
+              </thead>
+              <tbody>
+                {items.map(item => (
+                  <tr key={item.id}>
+                    <td>{item.code}</td>
+                    <td>{item.description}</td>
+                    <td>{item.group?.name || 'Sin grupo'}</td>
+                    <td>
+                      <div className="chip-list">
+                        {Object.entries(item.attributes || {}).map(([key, value]) => (
+                          <span key={key} className="badge">
+                            {key}: {value}
+                          </span>
+                        ))}
+                        {Object.keys(item.attributes || {}).length === 0 && <span>-</span>}
+                      </div>
+                    </td>
+                    <td>{item.stock?.general ?? 0}</td>
+                    <td>{item.stock?.overstockGeneral ?? 0}</td>
+                    <td>{item.stock?.overstockThibe ?? 0}</td>
+                    <td>{item.stock?.overstockArenal ?? 0}</td>
+                    {canWrite && (
+                      <td>
+                        <div className="inline-actions">
+                          <button type="button" className="secondary-button" onClick={() => handleEdit(item)}>
+                            Editar
+                          </button>
+                        </div>
+                      </td>
+                    )}
+                  </tr>
+                ))}
+                {items.length === 0 && (
+                  <tr>
+                    <td colSpan={canWrite ? 9 : 8} style={{ textAlign: 'center', padding: '1.5rem 0' }}>
+                      No se encontraron artículos para los filtros seleccionados.
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+        )}
+
+        <div className="flex-between" style={{ marginTop: '1rem' }}>
+          <span style={{ color: '#64748b', fontSize: '0.9rem' }}>
+            Página {page} de {totalPages}
+          </span>
+          <div className="inline-actions">
+            <button type="button" className="secondary-button" disabled={page === 1} onClick={() => setPage(prev => Math.max(1, prev - 1))}>
+              Anterior
+            </button>
+            <button
+              type="button"
+              className="secondary-button"
+              disabled={page === totalPages}
+              onClick={() => setPage(prev => Math.min(totalPages, prev + 1))}
+            >
+              Siguiente
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/movements/ApprovalsPage.jsx
+++ b/frontend/src/pages/movements/ApprovalsPage.jsx
@@ -1,0 +1,140 @@
+import { useEffect, useMemo, useState } from 'react';
+import useApi from '../../hooks/useApi.js';
+import { useAuth } from '../../context/AuthContext.jsx';
+import LoadingIndicator from '../../components/LoadingIndicator.jsx';
+import ErrorMessage from '../../components/ErrorMessage.jsx';
+
+const TYPE_LABELS = {
+  in: 'Entrada',
+  out: 'Salida',
+  transfer: 'Transferencia'
+};
+
+export default function ApprovalsPage() {
+  const api = useApi();
+  const { user } = useAuth();
+  const permissions = useMemo(() => user?.permissions || [], [user]);
+  const canApprove = permissions.includes('stock.approve');
+
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [requests, setRequests] = useState([]);
+  const [successMessage, setSuccessMessage] = useState('');
+
+  useEffect(() => {
+    let active = true;
+    const loadPending = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const response = await api.get('/stock/requests', { query: { status: 'pending' } });
+        if (!active) return;
+        setRequests(Array.isArray(response) ? response : []);
+      } catch (err) {
+        if (!active) return;
+        setError(err);
+      } finally {
+        if (active) {
+          setLoading(false);
+        }
+      }
+    };
+    if (canApprove) {
+      loadPending();
+    }
+    return () => {
+      active = false;
+    };
+  }, [api, canApprove]);
+
+  const handleApprove = async requestId => {
+    try {
+      await api.post(`/stock/approve/${requestId}`);
+      setRequests(prev => prev.filter(request => request.id !== requestId));
+      setSuccessMessage('Solicitud aprobada y ejecutada.');
+    } catch (err) {
+      setError(err);
+    }
+  };
+
+  const handleReject = async requestId => {
+    const reason = window.prompt('Indique el motivo del rechazo (opcional)');
+    if (reason === null) {
+      return;
+    }
+    try {
+      await api.post(`/stock/reject/${requestId}`, { reason });
+      setRequests(prev => prev.filter(request => request.id !== requestId));
+      setSuccessMessage('Solicitud rechazada correctamente.');
+    } catch (err) {
+      setError(err);
+    }
+  };
+
+  if (!canApprove) {
+    return <ErrorMessage error="No cuenta con permisos de aprobación." />;
+  }
+
+  return (
+    <div>
+      <h2>Bandeja de aprobación</h2>
+      <p style={{ color: '#475569', marginTop: '-0.4rem' }}>
+        Evalúe y apruebe o rechace las solicitudes de movimiento críticas. Cada acción quedará registrada en la auditoría.
+      </p>
+
+      {error && <ErrorMessage error={error} />}
+      {successMessage && <div className="success-message">{successMessage}</div>}
+
+      <div className="section-card">
+        <h3>Solicitudes pendientes</h3>
+        {loading ? (
+          <LoadingIndicator message="Buscando solicitudes pendientes..." />
+        ) : requests.length === 0 ? (
+          <p style={{ color: '#64748b' }}>No hay solicitudes pendientes de aprobación.</p>
+        ) : (
+          <div className="table-wrapper" style={{ marginTop: '1rem' }}>
+            <table>
+              <thead>
+                <tr>
+                  <th>Artículo</th>
+                  <th>Tipo</th>
+                  <th>Origen</th>
+                  <th>Destino</th>
+                  <th>Cantidad</th>
+                  <th>Cliente</th>
+                  <th>Solicitado por</th>
+                  <th>Fecha</th>
+                  <th>Acciones</th>
+                </tr>
+              </thead>
+              <tbody>
+                {requests.map(request => (
+                  <tr key={request.id}>
+                    <td>{request.item?.code || request.itemId}</td>
+                    <td>{TYPE_LABELS[request.type] || request.type}</td>
+                    <td>{request.fromList || '-'}</td>
+                    <td>{request.toList || '-'}</td>
+                    <td>{request.quantity}</td>
+                    <td>{request.customer?.name || '-'}</td>
+                    <td>{request.requestedBy?.username || 'N/D'}</td>
+                    <td>{new Date(request.requestedAt).toLocaleString('es-AR')}</td>
+                    <td>
+                      <div className="inline-actions">
+                        <button type="button" onClick={() => handleApprove(request.id)}>
+                          Aprobar
+                        </button>
+                        <button type="button" className="secondary-button" onClick={() => handleReject(request.id)}>
+                          Rechazar
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/movements/MovementRequestsPage.jsx
+++ b/frontend/src/pages/movements/MovementRequestsPage.jsx
@@ -1,0 +1,311 @@
+import { useEffect, useMemo, useState } from 'react';
+import useApi from '../../hooks/useApi.js';
+import { useAuth } from '../../context/AuthContext.jsx';
+import LoadingIndicator from '../../components/LoadingIndicator.jsx';
+import ErrorMessage from '../../components/ErrorMessage.jsx';
+
+const LIST_OPTIONS = [
+  { value: 'general', label: 'Stock General' },
+  { value: 'overstockGeneral', label: 'Sobrestock General' },
+  { value: 'overstockThibe', label: 'Sobrestock Thibe' },
+  { value: 'overstockArenal', label: 'Sobrestock Arenal' },
+  { value: 'customer', label: 'Cliente reservado' }
+];
+
+const TYPE_LABELS = {
+  in: 'Entrada',
+  out: 'Salida',
+  transfer: 'Transferencia'
+};
+
+export default function MovementRequestsPage() {
+  const api = useApi();
+  const { user } = useAuth();
+  const permissions = useMemo(() => user?.permissions || [], [user]);
+  const canRequest = permissions.includes('stock.request');
+
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [items, setItems] = useState([]);
+  const [customers, setCustomers] = useState([]);
+  const [requests, setRequests] = useState([]);
+  const [statusFilter, setStatusFilter] = useState('');
+  const [formValues, setFormValues] = useState({
+    itemId: '',
+    type: 'out',
+    fromList: 'general',
+    toList: 'customer',
+    quantity: 1,
+    reason: '',
+    customerId: ''
+  });
+  const [submitting, setSubmitting] = useState(false);
+  const [successMessage, setSuccessMessage] = useState('');
+
+  useEffect(() => {
+    let active = true;
+    const loadMetadata = async () => {
+      try {
+        const [itemsResponse, customersResponse] = await Promise.all([
+          api.get('/items', { query: { page: 1, pageSize: 100 } }),
+          api.get('/customers')
+        ]);
+        if (!active) return;
+        setItems(itemsResponse.items || []);
+        setCustomers(Array.isArray(customersResponse) ? customersResponse : []);
+      } catch (err) {
+        console.warn('No se pudieron cargar recursos de apoyo', err);
+      }
+    };
+    if (canRequest) {
+      loadMetadata();
+    }
+    return () => {
+      active = false;
+    };
+  }, [api, canRequest]);
+
+  useEffect(() => {
+    let active = true;
+    const loadRequests = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const response = await api.get('/stock/requests', {
+          query: statusFilter ? { status: statusFilter } : undefined
+        });
+        if (!active) return;
+        setRequests(Array.isArray(response) ? response : []);
+      } catch (err) {
+        if (!active) return;
+        setError(err);
+      } finally {
+        if (active) {
+          setLoading(false);
+        }
+      }
+    };
+    if (canRequest) {
+      loadRequests();
+    }
+    return () => {
+      active = false;
+    };
+  }, [api, canRequest, statusFilter]);
+
+  const handleFormChange = event => {
+    const { name, value } = event.target;
+    setFormValues(prev => ({ ...prev, [name]: value }));
+  };
+
+  const handleTypeChange = event => {
+    const value = event.target.value;
+    setFormValues(prev => ({
+      ...prev,
+      type: value,
+      fromList: value === 'in' ? '' : prev.fromList || 'general',
+      toList: value === 'out' ? '' : prev.toList || 'general'
+    }));
+  };
+
+  const handleSubmit = async event => {
+    event.preventDefault();
+    if (!canRequest) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const payload = {
+        itemId: formValues.itemId,
+        type: formValues.type,
+        quantity: Number(formValues.quantity),
+        reason: formValues.reason
+      };
+      if (formValues.fromList) payload.fromList = formValues.fromList;
+      if (formValues.toList) payload.toList = formValues.toList;
+      if (formValues.customerId) payload.customerId = formValues.customerId;
+      await api.post('/stock/request', payload);
+      setSuccessMessage('Solicitud registrada correctamente.');
+      setFormValues(prev => ({ ...prev, reason: '', quantity: 1 }));
+      const refreshed = await api.get('/stock/requests', {
+        query: statusFilter ? { status: statusFilter } : undefined
+      });
+      setRequests(Array.isArray(refreshed) ? refreshed : []);
+    } catch (err) {
+      setError(err);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const requiresCustomer = formValues.fromList === 'customer' || formValues.toList === 'customer';
+
+  if (!canRequest) {
+    return <ErrorMessage error="No cuenta con permisos para solicitar movimientos." />;
+  }
+
+  return (
+    <div>
+      <h2>Solicitudes de movimiento</h2>
+      <p style={{ color: '#475569', marginTop: '-0.4rem' }}>
+        Genere solicitudes de entrada, salida o transferencia de stock. Las salidas y movimientos críticos requerirán aprobación.
+      </p>
+
+      {error && <ErrorMessage error={error} />}
+      {successMessage && <div className="success-message">{successMessage}</div>}
+
+      <div className="section-card">
+        <h3>Nueva solicitud</h3>
+        <form className="form-grid" style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))' }} onSubmit={handleSubmit}>
+          <div className="input-group">
+            <label htmlFor="itemId">Artículo *</label>
+            <select id="itemId" name="itemId" value={formValues.itemId} onChange={handleFormChange} required>
+              <option value="">Seleccione artículo</option>
+              {items.map(item => (
+                <option key={item.id} value={item.id}>
+                  {item.code} · {item.description}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="input-group">
+            <label htmlFor="type">Tipo *</label>
+            <select id="type" name="type" value={formValues.type} onChange={handleTypeChange}>
+              <option value="out">Salida</option>
+              <option value="in">Entrada</option>
+              <option value="transfer">Transferencia</option>
+            </select>
+          </div>
+          {formValues.type !== 'in' && (
+            <div className="input-group">
+              <label htmlFor="fromList">Desde</label>
+              <select id="fromList" name="fromList" value={formValues.fromList} onChange={handleFormChange} required={formValues.type !== 'in'}>
+                <option value="">Seleccione lista origen</option>
+                {LIST_OPTIONS.map(option => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
+          {formValues.type !== 'out' && (
+            <div className="input-group">
+              <label htmlFor="toList">Hacia</label>
+              <select id="toList" name="toList" value={formValues.toList} onChange={handleFormChange} required={formValues.type !== 'out'}>
+                <option value="">Seleccione lista destino</option>
+                {LIST_OPTIONS.map(option => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
+          <div className="input-group">
+            <label htmlFor="quantity">Cantidad *</label>
+            <input
+              id="quantity"
+              name="quantity"
+              type="number"
+              min="1"
+              value={formValues.quantity}
+              onChange={handleFormChange}
+              required
+            />
+          </div>
+          {requiresCustomer && (
+            <div className="input-group">
+              <label htmlFor="customerId">Cliente</label>
+              <select id="customerId" name="customerId" value={formValues.customerId} onChange={handleFormChange} required>
+                <option value="">Seleccione cliente</option>
+                {customers.map(customer => (
+                  <option key={customer.id} value={customer.id}>
+                    {customer.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
+          <div className="input-group" style={{ gridColumn: '1 / -1' }}>
+            <label htmlFor="reason">Motivo</label>
+            <textarea
+              id="reason"
+              name="reason"
+              value={formValues.reason}
+              onChange={handleFormChange}
+              rows={2}
+              placeholder="Ej: Reserva para cliente, entrega a tienda, devolución, etc."
+            />
+          </div>
+          <div>
+            <button type="submit" disabled={submitting}>
+              {submitting ? 'Enviando...' : 'Registrar solicitud'}
+            </button>
+          </div>
+        </form>
+      </div>
+
+      <div className="section-card">
+        <div className="flex-between">
+          <h3>Historial de solicitudes</h3>
+          <div className="input-group" style={{ maxWidth: '220px' }}>
+            <label htmlFor="statusFilter">Estado</label>
+            <select id="statusFilter" value={statusFilter} onChange={event => setStatusFilter(event.target.value)}>
+              <option value="">Todos</option>
+              <option value="pending">Pendientes</option>
+              <option value="approved">Aprobadas</option>
+              <option value="rejected">Rechazadas</option>
+              <option value="executed">Ejecutadas</option>
+            </select>
+          </div>
+        </div>
+
+        {loading ? (
+          <LoadingIndicator message="Cargando solicitudes..." />
+        ) : (
+          <div className="table-wrapper" style={{ marginTop: '1rem' }}>
+            <table>
+              <thead>
+                <tr>
+                  <th>Artículo</th>
+                  <th>Tipo</th>
+                  <th>Origen</th>
+                  <th>Destino</th>
+                  <th>Cantidad</th>
+                  <th>Cliente</th>
+                  <th>Estado</th>
+                  <th>Solicitado por</th>
+                  <th>Fecha</th>
+                </tr>
+              </thead>
+              <tbody>
+                {requests.map(request => (
+                  <tr key={request.id}>
+                    <td>{request.item?.code || request.itemId}</td>
+                    <td>{TYPE_LABELS[request.type] || request.type}</td>
+                    <td>{request.fromList || '-'}</td>
+                    <td>{request.toList || '-'}</td>
+                    <td>{request.quantity}</td>
+                    <td>{request.customer?.name || '-'}</td>
+                    <td>
+                      <span className={`badge ${request.status}`}>{request.status}</span>
+                    </td>
+                    <td>{request.requestedBy?.username || 'N/D'}</td>
+                    <td>{new Date(request.requestedAt).toLocaleString('es-AR')}</td>
+                  </tr>
+                ))}
+                {requests.length === 0 && (
+                  <tr>
+                    <td colSpan={9} style={{ textAlign: 'center', padding: '1.5rem 0' }}>
+                      No se registran solicitudes con los filtros aplicados.
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/reports/ReportsPage.jsx
+++ b/frontend/src/pages/reports/ReportsPage.jsx
@@ -1,0 +1,204 @@
+import { useEffect, useMemo, useState } from 'react';
+import useApi from '../../hooks/useApi.js';
+import { useAuth } from '../../context/AuthContext.jsx';
+import LoadingIndicator from '../../components/LoadingIndicator.jsx';
+import ErrorMessage from '../../components/ErrorMessage.jsx';
+import { exportToCsv } from '../../utils/export.js';
+
+export default function ReportsPage() {
+  const api = useApi();
+  const { user } = useAuth();
+  const permissions = useMemo(() => user?.permissions || [], [user]);
+  const canViewReports = permissions.includes('reports.read');
+
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [stockData, setStockData] = useState([]);
+  const [groups, setGroups] = useState([]);
+  const [filters, setFilters] = useState({ groupId: '', search: '' });
+
+  useEffect(() => {
+    let active = true;
+    const load = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const [stockResponse, groupsResponse] = await Promise.all([
+          api.get('/reports/stock'),
+          api.get('/groups').catch(() => [])
+        ]);
+        if (!active) return;
+        setStockData(Array.isArray(stockResponse) ? stockResponse : []);
+        setGroups(Array.isArray(groupsResponse) ? groupsResponse : []);
+      } catch (err) {
+        if (!active) return;
+        setError(err);
+      } finally {
+        if (active) {
+          setLoading(false);
+        }
+      }
+    };
+    if (canViewReports) {
+      load();
+    } else {
+      setLoading(false);
+      setError('No tiene permisos para acceder a los reportes.');
+    }
+    return () => {
+      active = false;
+    };
+  }, [api, canViewReports]);
+
+  const filteredData = useMemo(() => {
+    return stockData.filter(item => {
+      const matchesGroup = !filters.groupId || item.groupId === filters.groupId;
+      const matchesSearch =
+        !filters.search ||
+        item.code.toLowerCase().includes(filters.search.toLowerCase()) ||
+        item.description.toLowerCase().includes(filters.search.toLowerCase());
+      return matchesGroup && matchesSearch;
+    });
+  }, [filters.groupId, filters.search, stockData]);
+
+  const totals = useMemo(() => {
+    return filteredData.reduce(
+      (accumulator, item) => {
+        const stock = item.stock || {};
+        accumulator.general += Number(stock.general || 0);
+        accumulator.overstockGeneral += Number(stock.overstockGeneral || 0);
+        accumulator.overstockThibe += Number(stock.overstockThibe || 0);
+        accumulator.overstockArenal += Number(stock.overstockArenal || 0);
+        return accumulator;
+      },
+      { general: 0, overstockGeneral: 0, overstockThibe: 0, overstockArenal: 0 }
+    );
+  }, [filteredData]);
+
+  const handleExport = () => {
+    const rows = filteredData.map(item => ({
+      codigo: item.code,
+      descripcion: item.description,
+      grupo: item.group?.name || 'Sin grupo',
+      stock_general: item.stock?.general || 0,
+      sobrestock_general: item.stock?.overstockGeneral || 0,
+      sobrestock_thibe: item.stock?.overstockThibe || 0,
+      sobrestock_arenal: item.stock?.overstockArenal || 0
+    }));
+    exportToCsv('reporte_stock.csv', rows);
+  };
+
+  if (!canViewReports) {
+    return <ErrorMessage error="No tiene permisos para acceder a esta sección." />;
+  }
+
+  if (loading) {
+    return <LoadingIndicator message="Generando reporte de stock..." />;
+  }
+
+  return (
+    <div>
+      <h2>Reportes de stock</h2>
+      <p style={{ color: '#475569', marginTop: '-0.4rem' }}>
+        Analice el inventario consolidado por grupo y exporte la información para uso externo.
+      </p>
+
+      {error && <ErrorMessage error={error} />}
+
+      <div className="section-card">
+        <div className="form-grid" style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))' }}>
+          <div className="input-group">
+            <label htmlFor="search">Buscar</label>
+            <input
+              id="search"
+              value={filters.search}
+              onChange={event => setFilters(prev => ({ ...prev, search: event.target.value }))}
+              placeholder="Código o descripción"
+            />
+          </div>
+          <div className="input-group">
+            <label htmlFor="group">Grupo</label>
+            <select
+              id="group"
+              value={filters.groupId}
+              onChange={event => setFilters(prev => ({ ...prev, groupId: event.target.value }))}
+            >
+              <option value="">Todos</option>
+              {groups.map(group => (
+                <option key={group.id} value={group.id}>
+                  {group.name}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div style={{ display: 'flex', alignItems: 'flex-end' }}>
+            <button type="button" onClick={handleExport} disabled={filteredData.length === 0}>
+              Exportar CSV
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <div className="section-card">
+        <h3>Resumen</h3>
+        <div className="metrics-grid">
+          <div className="metric-card">
+            <h3>Stock general</h3>
+            <p>{totals.general.toLocaleString('es-AR')}</p>
+          </div>
+          <div className="metric-card">
+            <h3>Sobrestock general</h3>
+            <p>{totals.overstockGeneral.toLocaleString('es-AR')}</p>
+          </div>
+          <div className="metric-card">
+            <h3>Sobrestock Thibe</h3>
+            <p>{totals.overstockThibe.toLocaleString('es-AR')}</p>
+          </div>
+          <div className="metric-card">
+            <h3>Sobrestock Arenal</h3>
+            <p>{totals.overstockArenal.toLocaleString('es-AR')}</p>
+          </div>
+        </div>
+      </div>
+
+      <div className="section-card">
+        <h3>Detalle por artículo</h3>
+        <div className="table-wrapper" style={{ marginTop: '1rem' }}>
+          <table>
+            <thead>
+              <tr>
+                <th>Código</th>
+                <th>Descripción</th>
+                <th>Grupo</th>
+                <th>Stock General</th>
+                <th>Sobrestock General</th>
+                <th>Sobrestock Thibe</th>
+                <th>Sobrestock Arenal</th>
+              </tr>
+            </thead>
+            <tbody>
+              {filteredData.map(item => (
+                <tr key={item.id}>
+                  <td>{item.code}</td>
+                  <td>{item.description}</td>
+                  <td>{item.group?.name || 'Sin grupo'}</td>
+                  <td>{item.stock?.general || 0}</td>
+                  <td>{item.stock?.overstockGeneral || 0}</td>
+                  <td>{item.stock?.overstockThibe || 0}</td>
+                  <td>{item.stock?.overstockArenal || 0}</td>
+                </tr>
+              ))}
+              {filteredData.length === 0 && (
+                <tr>
+                  <td colSpan={7} style={{ textAlign: 'center', padding: '1.5rem 0' }}>
+                    No hay datos para los filtros seleccionados.
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/users/UsersPage.jsx
+++ b/frontend/src/pages/users/UsersPage.jsx
@@ -1,0 +1,280 @@
+import { useEffect, useMemo, useState } from 'react';
+import useApi from '../../hooks/useApi.js';
+import { useAuth } from '../../context/AuthContext.jsx';
+import LoadingIndicator from '../../components/LoadingIndicator.jsx';
+import ErrorMessage from '../../components/ErrorMessage.jsx';
+
+export default function UsersPage() {
+  const api = useApi();
+  const { user } = useAuth();
+  const permissions = useMemo(() => user?.permissions || [], [user]);
+  const canRead = permissions.includes('users.read');
+  const canWrite = permissions.includes('users.write');
+
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [users, setUsers] = useState([]);
+  const [roles, setRoles] = useState([]);
+  const [selectedUser, setSelectedUser] = useState(null);
+  const [formValues, setFormValues] = useState({
+    username: '',
+    email: '',
+    password: '',
+    roleId: '',
+    status: 'active'
+  });
+  const [saving, setSaving] = useState(false);
+  const [successMessage, setSuccessMessage] = useState('');
+
+  useEffect(() => {
+    let active = true;
+    const load = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const [usersResponse, rolesResponse] = await Promise.all([
+          api.get('/users'),
+          api.get('/roles')
+        ]);
+        if (!active) return;
+        setUsers(Array.isArray(usersResponse) ? usersResponse : []);
+        setRoles(Array.isArray(rolesResponse) ? rolesResponse : []);
+      } catch (err) {
+        if (!active) return;
+        setError(err);
+      } finally {
+        if (active) {
+          setLoading(false);
+        }
+      }
+    };
+    if (canRead) {
+      load();
+    } else {
+      setLoading(false);
+    }
+    return () => {
+      active = false;
+    };
+  }, [api, canRead]);
+
+  const handleFormChange = event => {
+    const { name, value } = event.target;
+    setFormValues(prev => ({ ...prev, [name]: value }));
+  };
+
+  const handleEdit = userToEdit => {
+    setSelectedUser(userToEdit);
+    setFormValues({
+      username: userToEdit.username,
+      email: userToEdit.email,
+      password: '',
+      roleId: userToEdit.roleId || '',
+      status: userToEdit.status || 'active'
+    });
+  };
+
+  const resetForm = () => {
+    setSelectedUser(null);
+    setFormValues({ username: '', email: '', password: '', roleId: '', status: 'active' });
+  };
+
+  const handleSubmit = async event => {
+    event.preventDefault();
+    if (!canWrite) return;
+    setSaving(true);
+    setError(null);
+    try {
+      if (selectedUser) {
+        const payload = {
+          username: formValues.username,
+          email: formValues.email,
+          roleId: formValues.roleId,
+          status: formValues.status
+        };
+        if (formValues.password) {
+          payload.password = formValues.password;
+        }
+        const updated = await api.put(`/users/${selectedUser.id}`, payload);
+        setUsers(prev => prev.map(current => (current.id === updated.id ? updated : current)));
+        setSuccessMessage(`Usuario ${updated.username} actualizado.`);
+      } else {
+        const created = await api.post('/users', formValues);
+        setUsers(prev => [created, ...prev]);
+        setSuccessMessage(`Usuario ${created.username} creado.`);
+      }
+      resetForm();
+    } catch (err) {
+      setError(err);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDisable = async userId => {
+    if (!canWrite) return;
+    if (!window.confirm('¿Seguro desea deshabilitar este usuario?')) {
+      return;
+    }
+    try {
+      await api.delete(`/users/${userId}`);
+      setUsers(prev => prev.map(current => (current.id === userId ? { ...current, status: 'disabled' } : current)));
+      setSuccessMessage('Usuario deshabilitado.');
+    } catch (err) {
+      setError(err);
+    }
+  };
+
+  if (!canRead) {
+    return <ErrorMessage error="No tiene permisos para ver usuarios." />;
+  }
+
+  if (loading) {
+    return <LoadingIndicator message="Cargando usuarios..." />;
+  }
+
+  return (
+    <div>
+      <h2>Administración de usuarios</h2>
+      <p style={{ color: '#475569', marginTop: '-0.4rem' }}>
+        Gestione cuentas, roles y estados de acceso al sistema.
+      </p>
+
+      {error && <ErrorMessage error={error} />}
+      {successMessage && <div className="success-message">{successMessage}</div>}
+
+      <div className="section-card">
+        <div className="table-wrapper">
+          <table>
+            <thead>
+              <tr>
+                <th>Usuario</th>
+                <th>Email</th>
+                <th>Rol</th>
+                <th>Permisos</th>
+                <th>Estado</th>
+                <th>Último acceso</th>
+                {canWrite && <th>Acciones</th>}
+              </tr>
+            </thead>
+            <tbody>
+              {users.map(current => (
+                <tr key={current.id}>
+                  <td>{current.username}</td>
+                  <td>{current.email}</td>
+                  <td>{current.role || '-'}</td>
+                  <td>
+                    <div className="chip-list">
+                      {current.permissions?.map(permission => (
+                        <span key={permission} className="badge">
+                          {permission}
+                        </span>
+                      ))}
+                    </div>
+                  </td>
+                  <td>
+                    <span className={`badge ${current.status === 'active' ? 'approved' : 'rejected'}`}>
+                      {current.status}
+                    </span>
+                  </td>
+                  <td>{current.lastLoginAt ? new Date(current.lastLoginAt).toLocaleString('es-AR') : '-'}</td>
+                  {canWrite && (
+                    <td>
+                      <div className="inline-actions">
+                        <button type="button" className="secondary-button" onClick={() => handleEdit(current)}>
+                          Editar
+                        </button>
+                        {current.status !== 'disabled' && (
+                          <button type="button" onClick={() => handleDisable(current.id)}>
+                            Deshabilitar
+                          </button>
+                        )}
+                      </div>
+                    </td>
+                  )}
+                </tr>
+              ))}
+              {users.length === 0 && (
+                <tr>
+                  <td colSpan={canWrite ? 7 : 6} style={{ textAlign: 'center', padding: '1.5rem 0' }}>
+                    No hay usuarios registrados.
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      {canWrite && (
+        <div className="section-card">
+          <h3>{selectedUser ? 'Editar usuario' : 'Nuevo usuario'}</h3>
+          <form className="form-grid" style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))' }} onSubmit={handleSubmit}>
+            <div className="input-group">
+              <label htmlFor="username">Usuario *</label>
+              <input
+                id="username"
+                name="username"
+                value={formValues.username}
+                onChange={handleFormChange}
+                required
+              />
+            </div>
+            <div className="input-group">
+              <label htmlFor="email">Email *</label>
+              <input
+                id="email"
+                name="email"
+                type="email"
+                value={formValues.email}
+                onChange={handleFormChange}
+                required
+              />
+            </div>
+            <div className="input-group">
+              <label htmlFor="roleId">Rol *</label>
+              <select id="roleId" name="roleId" value={formValues.roleId} onChange={handleFormChange} required>
+                <option value="">Seleccione rol</option>
+                {roles.map(role => (
+                  <option key={role.id} value={role.id}>
+                    {role.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="input-group">
+              <label htmlFor="status">Estado</label>
+              <select id="status" name="status" value={formValues.status} onChange={handleFormChange}>
+                <option value="active">Activo</option>
+                <option value="disabled">Deshabilitado</option>
+              </select>
+            </div>
+            <div className="input-group">
+              <label htmlFor="password">Contraseña {selectedUser ? '(opcional)' : '*'}</label>
+              <input
+                id="password"
+                name="password"
+                type="password"
+                value={formValues.password}
+                onChange={handleFormChange}
+                required={!selectedUser}
+              />
+            </div>
+            <div>
+              <button type="submit" disabled={saving}>
+                {saving ? 'Guardando...' : selectedUser ? 'Actualizar usuario' : 'Crear usuario'}
+              </button>
+            </div>
+            {selectedUser && (
+              <div>
+                <button type="button" className="secondary-button" onClick={resetForm}>
+                  Cancelar
+                </button>
+              </div>
+            )}
+          </form>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/utils/export.js
+++ b/frontend/src/utils/export.js
@@ -1,0 +1,31 @@
+function escapeCell(value) {
+  if (value === null || value === undefined) {
+    return '';
+  }
+  const stringValue = String(value);
+  if (stringValue.includes(';') || stringValue.includes('"') || stringValue.includes('\n')) {
+    return `"${stringValue.replace(/"/g, '""')}"`;
+  }
+  return stringValue;
+}
+
+export function exportToCsv(filename, rows) {
+  if (!rows || rows.length === 0) {
+    return;
+  }
+  const headers = Object.keys(rows[0]);
+  const csvLines = [headers.join(';')];
+  rows.forEach(row => {
+    const line = headers.map(header => escapeCell(row[header])).join(';');
+    csvLines.push(line);
+  });
+  const blob = new Blob([csvLines.join('\n')], { type: 'text/csv;charset=utf-8;' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.setAttribute('download', filename);
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    host: '0.0.0.0',
+    port: 5173
+  }
+});


### PR DESCRIPTION
## Resumen
- crear aplicación frontend en React con enrutamiento protegido, autenticación y refresco automático de tokens
- implementar paneles completos para artículos, solicitudes, aprobaciones, clientes, reportes, auditoría y usuarios
- añadir estilos globales, componentes compartidos y utilidades como exportación a CSV

## Pruebas
- `npm install` *(falla: 403 Forbidden desde registry.npmjs.org en este entorno)*

------
https://chatgpt.com/codex/tasks/task_e_68d19b093ed8832a9d2f68593bd40f5d