### PR TITLE
Improve customer maintenance workflows

### DIFF
--- a/backend/src/routes/customers.js
+++ b/backend/src/routes/customers.js
@@ -8,12 +8,19 @@ const { ensureCustomerExists } = require('../services/stockService');
 
 const router = express.Router();
 
+const serializeCustomer = customer => ({
+  id: customer.id || (customer._id ? customer._id.toString() : undefined),
+  name: customer.name,
+  contactInfo: customer.contactInfo || '',
+  status: customer.status || 'active'
+});
+
 router.get(
   '/',
   requirePermission('items.read'),
   asyncHandler(async (req, res) => {
     const customers = await Customer.find().sort({ name: 1 });
-    res.json(customers);
+    res.json(customers.map(serializeCustomer));
   })
 );
 
@@ -30,7 +37,7 @@ router.post(
       contactInfo: contactInfo || '',
       status: status || 'active'
     });
-    res.status(201).json(customer);
+    res.status(201).json(serializeCustomer(customer));
   })
 );
 
@@ -53,7 +60,28 @@ router.put(
       customer.status = status;
     }
     await customer.save();
-    res.json(customer);
+    res.json(serializeCustomer(customer));
+  })
+);
+
+router.delete(
+  '/:id',
+  requirePermission('items.write'),
+  asyncHandler(async (req, res) => {
+    const { id } = req.params;
+    const customer = await Customer.findById(id);
+    if (!customer) {
+      throw new HttpError(404, 'Cliente no encontrado');
+    }
+
+    const hasReservedStock = await CustomerStock.exists({ customer: id, status: 'reserved' });
+    if (hasReservedStock) {
+      throw new HttpError(400, 'No se puede eliminar un cliente con stock reservado.');
+    }
+
+    await CustomerStock.deleteMany({ customer: id });
+    await customer.deleteOne();
+    res.json({ success: true });
   })
 );
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -227,6 +227,17 @@ th {
   background-color: rgba(37, 99, 235, 0.12);
 }
 
+.danger-button {
+  background-color: #ef4444;
+  color: #fff;
+  border: 1px solid #ef4444;
+}
+
+.danger-button:hover:not(:disabled) {
+  background-color: #dc2626;
+  border-color: #dc2626;
+}
+
 .input-group {
   display: flex;
   flex-direction: column;

--- a/quick_test_backend.bat
+++ b/quick_test_backend.bat
@@ -1,0 +1,34 @@
+@echo off
+REM Script para ejecutar una prueba rápida del backend
+SETLOCAL ENABLEDELAYEDEXPANSION
+
+REM Moverse al directorio del backend
+pushd "%~dp0backend"
+IF ERRORLEVEL 1 (
+    echo No se pudo acceder al directorio backend.
+    exit /b 1
+)
+
+REM Instalar dependencias (solo la primera vez tardará unos segundos)
+echo Instalando dependencias...
+call npm install
+IF ERRORLEVEL 1 (
+    echo Error al instalar dependencias.
+    popd
+    exit /b 1
+)
+
+REM Ejecutar el script de pruebas por defecto
+echo Ejecutando pruebas...
+call npm test
+IF ERRORLEVEL 1 (
+    echo Las pruebas devolvieron un error.
+    popd
+    exit /b 1
+)
+
+REM Volver al directorio original
+popd
+
+echo Prueba rapida finalizada correctamente.
+EXIT /B 0


### PR DESCRIPTION
## Summary
- normalize customer responses in the API and add a guarded delete endpoint that removes stock records when allowed
- redesign the customer management page to handle normalized IDs, provide create/edit/delete actions, and keep the reserved stock selector in sync
- add a danger button style for destructive actions in the frontend

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd6a4f5c50832a8b931590fd92239a