### PR TITLE
feat: track stock by boxes and units

### DIFF
--- a/backend/src/models/CustomerStock.js
+++ b/backend/src/models/CustomerStock.js
@@ -1,10 +1,18 @@
 const { Schema, model, Types } = require('mongoose');
 
+const quantitySchema = new Schema(
+  {
+    boxes: { type: Number, default: 0, min: 0 },
+    units: { type: Number, default: 0, min: 0 }
+  },
+  { _id: false }
+);
+
 const customerStockSchema = new Schema(
   {
     customer: { type: Types.ObjectId, ref: 'Customer', required: true },
     item: { type: Types.ObjectId, ref: 'Item', required: true },
-    quantity: { type: Number, required: true, min: 0 },
+    quantity: { type: quantitySchema, required: true, default: () => ({}) },
     status: { type: String, enum: ['reserved', 'delivered'], default: 'reserved' },
     boxLabel: { type: String, default: null, trim: true },
     dateCreated: { type: Date, default: Date.now },

--- a/backend/src/models/Item.js
+++ b/backend/src/models/Item.js
@@ -1,11 +1,19 @@
 const { Schema, model, Types } = require('mongoose');
 
+const quantitySchema = new Schema(
+  {
+    boxes: { type: Number, default: 0, min: 0 },
+    units: { type: Number, default: 0, min: 0 }
+  },
+  { _id: false }
+);
+
 const stockSchema = new Schema(
   {
-    general: { type: Number, default: 0, min: 0 },
-    overstockGeneral: { type: Number, default: 0, min: 0 },
-    overstockThibe: { type: Number, default: 0, min: 0 },
-    overstockArenal: { type: Number, default: 0, min: 0 }
+    general: { type: quantitySchema, default: () => ({}) },
+    overstockGeneral: { type: quantitySchema, default: () => ({}) },
+    overstockThibe: { type: quantitySchema, default: () => ({}) },
+    overstockArenal: { type: quantitySchema, default: () => ({}) }
   },
   { _id: false }
 );

--- a/backend/src/models/MovementRequest.js
+++ b/backend/src/models/MovementRequest.js
@@ -1,12 +1,20 @@
 const { Schema, model, Types } = require('mongoose');
 
+const quantitySchema = new Schema(
+  {
+    boxes: { type: Number, default: 0, min: 0 },
+    units: { type: Number, default: 0, min: 0 }
+  },
+  { _id: false }
+);
+
 const movementRequestSchema = new Schema(
   {
     item: { type: Types.ObjectId, ref: 'Item', required: true },
     type: { type: String, enum: ['in', 'out', 'transfer'], required: true },
     fromList: { type: String, default: null },
     toList: { type: String, default: null },
-    quantity: { type: Number, required: true, min: 1 },
+    quantity: { type: quantitySchema, required: true, default: () => ({}) },
     reason: { type: String, default: '' },
     requestedBy: { type: Types.ObjectId, ref: 'User', required: true },
     requestedAt: { type: Date, default: Date.now },

--- a/backend/src/routes/customers.js
+++ b/backend/src/routes/customers.js
@@ -4,7 +4,7 @@ const { HttpError } = require('../utils/errors');
 const { requirePermission } = require('../middlewares/auth');
 const Customer = require('../models/Customer');
 const CustomerStock = require('../models/CustomerStock');
-const { ensureCustomerExists } = require('../services/stockService');
+const { ensureCustomerExists, normalizeStoredQuantity } = require('../services/stockService');
 
 const router = express.Router();
 
@@ -104,7 +104,7 @@ router.get(
               description: record.item.description
             }
           : null,
-        quantity: record.quantity,
+        quantity: normalizeStoredQuantity(record.quantity),
         status: record.status,
         boxLabel: record.boxLabel,
         dateCreated: record.dateCreated,

--- a/backend/src/routes/items.js
+++ b/backend/src/routes/items.js
@@ -4,6 +4,7 @@ const { HttpError } = require('../utils/errors');
 const { requirePermission } = require('../middlewares/auth');
 const Item = require('../models/Item');
 const Group = require('../models/Group');
+const { normalizeQuantityInput } = require('../services/stockService');
 
 function toPlainAttributes(attributes) {
   if (!attributes) return {};
@@ -33,11 +34,7 @@ function buildStock(input = {}) {
   for (const key of ['general', 'overstockGeneral', 'overstockThibe', 'overstockArenal']) {
     const value = input[key];
     if (value === undefined) continue;
-    const numeric = Number(value);
-    if (Number.isNaN(numeric) || numeric < 0) {
-      throw new HttpError(400, 'Stock inválido');
-    }
-    stock[key] = numeric;
+    stock[key] = normalizeQuantityInput(value, { allowZero: true, fieldName: `Stock ${key}` });
   }
   return stock;
 }

--- a/backend/src/routes/stock.js
+++ b/backend/src/routes/stock.js
@@ -8,7 +8,8 @@ const {
   executeMovement,
   addMovementLog,
   ensureCustomerExists,
-  findItemOrThrow
+  findItemOrThrow,
+  normalizeStoredQuantity
 } = require('../services/stockService');
 
 function serializeUserSummary(user) {
@@ -39,7 +40,7 @@ function serializeMovementRequest(doc) {
     type: doc.type,
     fromList: doc.fromList,
     toList: doc.toList,
-    quantity: doc.quantity,
+    quantity: normalizeStoredQuantity(doc.quantity),
     reason: doc.reason,
     boxLabel: doc.boxLabel || null,
     requestedBy: doc.populated('requestedBy') ? serializeUserSummary(doc.requestedBy) : doc.requestedBy,
@@ -74,7 +75,7 @@ router.post(
   requirePermission('stock.request'),
   asyncHandler(async (req, res) => {
     const body = req.body || {};
-    validateMovementPayload(body);
+    const { quantity } = validateMovementPayload(body);
     const normalizedBoxLabel =
       typeof body.boxLabel === 'string' && body.boxLabel.trim().length > 0
         ? body.boxLabel.trim()
@@ -88,7 +89,7 @@ router.post(
       type: body.type,
       fromList: body.fromList || null,
       toList: body.toList || null,
-      quantity: body.quantity,
+      quantity,
       reason: body.reason || '',
       requestedBy: req.user.id,
       requestedAt: new Date(),

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -3,6 +3,7 @@ import useApi from '../hooks/useApi.js';
 import { useAuth } from '../context/AuthContext.jsx';
 import LoadingIndicator from '../components/LoadingIndicator.jsx';
 import ErrorMessage from '../components/ErrorMessage.jsx';
+import { formatQuantity, sumQuantities, ensureQuantity } from '../utils/quantity.js';
 
 export default function DashboardPage() {
   const api = useApi();
@@ -60,15 +61,20 @@ export default function DashboardPage() {
   const metrics = useMemo(() => {
     const totals = {
       items: stockData.length,
-      general: 0,
-      overstock: 0,
+      general: { boxes: 0, units: 0 },
+      overstock: { boxes: 0, units: 0 },
       customers: customers.length,
       pending: pendingRequests.filter(request => request.status === 'pending').length
     };
     stockData.forEach(item => {
       const stock = item.stock || {};
-      totals.general += Number(stock.general || 0);
-      totals.overstock += Number(stock.overstockGeneral || 0) + Number(stock.overstockThibe || 0) + Number(stock.overstockArenal || 0);
+      totals.general = sumQuantities(totals.general, stock.general);
+      totals.overstock = sumQuantities(
+        totals.overstock,
+        stock.overstockGeneral,
+        stock.overstockThibe,
+        stock.overstockArenal
+      );
     });
     return totals;
   }, [customers.length, pendingRequests, stockData]);
@@ -77,11 +83,18 @@ export default function DashboardPage() {
     const accumulator = new Map();
     stockData.forEach(item => {
       const groupName = item.group?.name || 'Sin grupo asignado';
-      const previous = accumulator.get(groupName) || 0;
-      accumulator.set(groupName, previous + Number(item.stock?.general || 0));
+      const previous = accumulator.get(groupName) || { boxes: 0, units: 0 };
+      accumulator.set(groupName, sumQuantities(previous, item.stock?.general));
     });
     return Array.from(accumulator.entries())
-      .sort((a, b) => b[1] - a[1])
+      .sort((a, b) => {
+        const qa = ensureQuantity(a[1]);
+        const qb = ensureQuantity(b[1]);
+        if (qa.boxes !== qb.boxes) {
+          return qb.boxes - qa.boxes;
+        }
+        return qb.units - qa.units;
+      })
       .slice(0, 5);
   }, [stockData]);
 
@@ -106,12 +119,12 @@ export default function DashboardPage() {
         </div>
         <div className="metric-card">
           <h3>Stock general</h3>
-          <p>{metrics.general.toLocaleString('es-AR')}</p>
-          <span style={{ fontSize: '0.8rem', color: '#64748b' }}>Unidades en depósito principal</span>
+          <p>{formatQuantity(metrics.general)}</p>
+          <span style={{ fontSize: '0.8rem', color: '#64748b' }}>Cajas y unidades en depósito principal</span>
         </div>
         <div className="metric-card">
           <h3>Sobrestock</h3>
-          <p>{metrics.overstock.toLocaleString('es-AR')}</p>
+          <p>{formatQuantity(metrics.overstock)}</p>
           <span style={{ fontSize: '0.8rem', color: '#64748b' }}>General + Thibe + Arenal Import</span>
         </div>
         <div className="metric-card">
@@ -130,7 +143,7 @@ export default function DashboardPage() {
         <div className="section-card">
           <div className="flex-between">
             <h2>Top 5 grupos por stock general</h2>
-            <span style={{ color: '#64748b', fontSize: '0.85rem' }}>Basado en unidades disponibles</span>
+            <span style={{ color: '#64748b', fontSize: '0.85rem' }}>Basado en cajas y unidades disponibles</span>
           </div>
           <div className="table-wrapper">
             <table>
@@ -144,7 +157,7 @@ export default function DashboardPage() {
                 {topGroups.map(([group, quantity]) => (
                   <tr key={group}>
                     <td>{group}</td>
-                    <td>{quantity.toLocaleString('es-AR')}</td>
+                    <td>{formatQuantity(quantity)}</td>
                   </tr>
                 ))}
               </tbody>
@@ -182,7 +195,7 @@ export default function DashboardPage() {
                     <td className="badge pending">{request.type}</td>
                     <td>{request.fromList || '-'}</td>
                     <td>{request.toList || '-'}</td>
-                    <td>{request.quantity}</td>
+                    <td>{formatQuantity(request.quantity)}</td>
                     <td>
                       <span className={`badge ${request.status}`}>{request.status}</span>
                     </td>

--- a/frontend/src/pages/items/ItemsPage.jsx
+++ b/frontend/src/pages/items/ItemsPage.jsx
@@ -3,6 +3,7 @@ import useApi from '../../hooks/useApi.js';
 import { useAuth } from '../../context/AuthContext.jsx';
 import LoadingIndicator from '../../components/LoadingIndicator.jsx';
 import ErrorMessage from '../../components/ErrorMessage.jsx';
+import { ensureQuantity, formatQuantity } from '../../utils/quantity.js';
 
 const ATTRIBUTES = ['gender', 'size', 'color', 'material', 'season', 'fit'];
 
@@ -31,10 +32,14 @@ export default function ItemsPage() {
     material: '',
     season: '',
     fit: '',
-    stockGeneral: '',
-    overstockGeneral: '',
-    overstockThibe: '',
-    overstockArenal: ''
+    stockGeneralBoxes: '',
+    stockGeneralUnits: '',
+    overstockGeneralBoxes: '',
+    overstockGeneralUnits: '',
+    overstockThibeBoxes: '',
+    overstockThibeUnits: '',
+    overstockArenalBoxes: '',
+    overstockArenalUnits: ''
   });
   const [saving, setSaving] = useState(false);
   const [successMessage, setSuccessMessage] = useState('');
@@ -108,10 +113,14 @@ export default function ItemsPage() {
       material: '',
       season: '',
       fit: '',
-      stockGeneral: '',
-      overstockGeneral: '',
-      overstockThibe: '',
-      overstockArenal: ''
+      stockGeneralBoxes: '',
+      stockGeneralUnits: '',
+      overstockGeneralBoxes: '',
+      overstockGeneralUnits: '',
+      overstockThibeBoxes: '',
+      overstockThibeUnits: '',
+      overstockArenalBoxes: '',
+      overstockArenalUnits: ''
     });
     setEditingItem(null);
   };
@@ -127,14 +136,40 @@ export default function ItemsPage() {
   };
 
   const buildPayload = () => {
-    const stock = {
-      general: formValues.stockGeneral === '' ? undefined : Number(formValues.stockGeneral),
-      overstockGeneral:
-        formValues.overstockGeneral === '' ? undefined : Number(formValues.overstockGeneral),
-      overstockThibe: formValues.overstockThibe === '' ? undefined : Number(formValues.overstockThibe),
-      overstockArenal:
-        formValues.overstockArenal === '' ? undefined : Number(formValues.overstockArenal)
-    };
+    const stock = {};
+    const STOCK_FIELDS = [
+      {
+        key: 'general',
+        boxesField: 'stockGeneralBoxes',
+        unitsField: 'stockGeneralUnits'
+      },
+      {
+        key: 'overstockGeneral',
+        boxesField: 'overstockGeneralBoxes',
+        unitsField: 'overstockGeneralUnits'
+      },
+      {
+        key: 'overstockThibe',
+        boxesField: 'overstockThibeBoxes',
+        unitsField: 'overstockThibeUnits'
+      },
+      {
+        key: 'overstockArenal',
+        boxesField: 'overstockArenalBoxes',
+        unitsField: 'overstockArenalUnits'
+      }
+    ];
+
+    STOCK_FIELDS.forEach(({ key, boxesField, unitsField }) => {
+      const boxesValue = formValues[boxesField];
+      const unitsValue = formValues[unitsField];
+      if (boxesValue === '' && unitsValue === '') {
+        return;
+      }
+      const boxes = boxesValue === '' ? 0 : Number(boxesValue);
+      const units = unitsValue === '' ? 0 : Number(unitsValue);
+      stock[key] = { boxes, units };
+    });
     const attributes = {};
     ATTRIBUTES.forEach(attribute => {
       if (formValues[attribute]) {
@@ -204,6 +239,12 @@ export default function ItemsPage() {
 
   const handleEdit = item => {
     setEditingItem(item);
+    const general = ensureQuantity(item.stock?.general);
+    const overstockGeneral = ensureQuantity(item.stock?.overstockGeneral);
+    const overstockThibe = ensureQuantity(item.stock?.overstockThibe);
+    const overstockArenal = ensureQuantity(item.stock?.overstockArenal);
+    const normalizeField = value => (value === 0 ? '' : String(value));
+
     setFormValues({
       code: item.code,
       description: item.description,
@@ -214,10 +255,14 @@ export default function ItemsPage() {
       material: item.attributes?.material || '',
       season: item.attributes?.season || '',
       fit: item.attributes?.fit || '',
-      stockGeneral: item.stock?.general ?? '',
-      overstockGeneral: item.stock?.overstockGeneral ?? '',
-      overstockThibe: item.stock?.overstockThibe ?? '',
-      overstockArenal: item.stock?.overstockArenal ?? ''
+      stockGeneralBoxes: normalizeField(general.boxes),
+      stockGeneralUnits: normalizeField(general.units),
+      overstockGeneralBoxes: normalizeField(overstockGeneral.boxes),
+      overstockGeneralUnits: normalizeField(overstockGeneral.units),
+      overstockThibeBoxes: normalizeField(overstockThibe.boxes),
+      overstockThibeUnits: normalizeField(overstockThibe.units),
+      overstockArenalBoxes: normalizeField(overstockArenal.boxes),
+      overstockArenalUnits: normalizeField(overstockArenal.units)
     });
   };
 
@@ -330,46 +375,90 @@ export default function ItemsPage() {
             </div>
           ))}
           <div className="input-group">
-            <label htmlFor="stockGeneral">Stock General</label>
+            <label htmlFor="stockGeneralBoxes">Stock General (Cajas)</label>
             <input
-              id="stockGeneral"
-              name="stockGeneral"
+              id="stockGeneralBoxes"
+              name="stockGeneralBoxes"
               type="number"
               min="0"
-              value={formValues.stockGeneral}
+              value={formValues.stockGeneralBoxes}
               onChange={handleFormChange}
             />
           </div>
           <div className="input-group">
-            <label htmlFor="overstockGeneral">Sobrestock General</label>
+            <label htmlFor="stockGeneralUnits">Stock General (Unidades)</label>
             <input
-              id="overstockGeneral"
-              name="overstockGeneral"
+              id="stockGeneralUnits"
+              name="stockGeneralUnits"
               type="number"
               min="0"
-              value={formValues.overstockGeneral}
+              value={formValues.stockGeneralUnits}
               onChange={handleFormChange}
             />
           </div>
           <div className="input-group">
-            <label htmlFor="overstockThibe">Sobrestock Thibe</label>
+            <label htmlFor="overstockGeneralBoxes">Sobrestock General (Cajas)</label>
             <input
-              id="overstockThibe"
-              name="overstockThibe"
+              id="overstockGeneralBoxes"
+              name="overstockGeneralBoxes"
               type="number"
               min="0"
-              value={formValues.overstockThibe}
+              value={formValues.overstockGeneralBoxes}
               onChange={handleFormChange}
             />
           </div>
           <div className="input-group">
-            <label htmlFor="overstockArenal">Sobrestock Arenal</label>
+            <label htmlFor="overstockGeneralUnits">Sobrestock General (Unidades)</label>
             <input
-              id="overstockArenal"
-              name="overstockArenal"
+              id="overstockGeneralUnits"
+              name="overstockGeneralUnits"
               type="number"
               min="0"
-              value={formValues.overstockArenal}
+              value={formValues.overstockGeneralUnits}
+              onChange={handleFormChange}
+            />
+          </div>
+          <div className="input-group">
+            <label htmlFor="overstockThibeBoxes">Sobrestock Thibe (Cajas)</label>
+            <input
+              id="overstockThibeBoxes"
+              name="overstockThibeBoxes"
+              type="number"
+              min="0"
+              value={formValues.overstockThibeBoxes}
+              onChange={handleFormChange}
+            />
+          </div>
+          <div className="input-group">
+            <label htmlFor="overstockThibeUnits">Sobrestock Thibe (Unidades)</label>
+            <input
+              id="overstockThibeUnits"
+              name="overstockThibeUnits"
+              type="number"
+              min="0"
+              value={formValues.overstockThibeUnits}
+              onChange={handleFormChange}
+            />
+          </div>
+          <div className="input-group">
+            <label htmlFor="overstockArenalBoxes">Sobrestock Arenal (Cajas)</label>
+            <input
+              id="overstockArenalBoxes"
+              name="overstockArenalBoxes"
+              type="number"
+              min="0"
+              value={formValues.overstockArenalBoxes}
+              onChange={handleFormChange}
+            />
+          </div>
+          <div className="input-group">
+            <label htmlFor="overstockArenalUnits">Sobrestock Arenal (Unidades)</label>
+            <input
+              id="overstockArenalUnits"
+              name="overstockArenalUnits"
+              type="number"
+              min="0"
+              value={formValues.overstockArenalUnits}
               onChange={handleFormChange}
             />
           </div>
@@ -491,10 +580,10 @@ export default function ItemsPage() {
                         {Object.keys(item.attributes || {}).length === 0 && <span>-</span>}
                       </div>
                     </td>
-                    <td>{item.stock?.general ?? 0}</td>
-                    <td>{item.stock?.overstockGeneral ?? 0}</td>
-                    <td>{item.stock?.overstockThibe ?? 0}</td>
-                    <td>{item.stock?.overstockArenal ?? 0}</td>
+                    <td>{formatQuantity(item.stock?.general)}</td>
+                    <td>{formatQuantity(item.stock?.overstockGeneral)}</td>
+                    <td>{formatQuantity(item.stock?.overstockThibe)}</td>
+                    <td>{formatQuantity(item.stock?.overstockArenal)}</td>
                     {canWrite && (
                       <td>
                         <div className="inline-actions">

--- a/frontend/src/pages/movements/ApprovalsPage.jsx
+++ b/frontend/src/pages/movements/ApprovalsPage.jsx
@@ -3,6 +3,7 @@ import useApi from '../../hooks/useApi.js';
 import { useAuth } from '../../context/AuthContext.jsx';
 import LoadingIndicator from '../../components/LoadingIndicator.jsx';
 import ErrorMessage from '../../components/ErrorMessage.jsx';
+import { formatQuantity } from '../../utils/quantity.js';
 
 const TYPE_LABELS = {
   in: 'Entrada',
@@ -115,7 +116,7 @@ export default function ApprovalsPage() {
                     <td>{TYPE_LABELS[request.type] || request.type}</td>
                     <td>{request.fromList || '-'}</td>
                     <td>{request.toList || '-'}</td>
-                    <td>{request.quantity}</td>
+                    <td>{formatQuantity(request.quantity)}</td>
                     <td>{request.customer?.name || '-'}</td>
                     <td>{request.boxLabel || '-'}</td>
                     <td>{request.requestedBy?.username || 'N/D'}</td>

--- a/frontend/src/utils/quantity.js
+++ b/frontend/src/utils/quantity.js
@@ -1,0 +1,49 @@
+export function ensureQuantity(quantity) {
+  if (quantity === undefined || quantity === null) {
+    return { boxes: 0, units: 0 };
+  }
+  if (typeof quantity === 'number') {
+    return { boxes: 0, units: Math.max(0, Math.trunc(quantity)) };
+  }
+  const boxes = Number(quantity.boxes ?? 0);
+  const units = Number(quantity.units ?? 0);
+  return {
+    boxes: Number.isFinite(boxes) ? Math.max(0, Math.trunc(boxes)) : 0,
+    units: Number.isFinite(units) ? Math.max(0, Math.trunc(units)) : 0
+  };
+}
+
+export function sumQuantities(...quantities) {
+  return quantities.reduce(
+    (acc, current) => {
+      const normalized = ensureQuantity(current);
+      return {
+        boxes: acc.boxes + normalized.boxes,
+        units: acc.units + normalized.units
+      };
+    },
+    { boxes: 0, units: 0 }
+  );
+}
+
+export function subtractQuantities(base, amount) {
+  const minuend = ensureQuantity(base);
+  const subtrahend = ensureQuantity(amount);
+  return {
+    boxes: Math.max(0, minuend.boxes - subtrahend.boxes),
+    units: Math.max(0, minuend.units - subtrahend.units)
+  };
+}
+
+export function isQuantityZero(quantity) {
+  const normalized = ensureQuantity(quantity);
+  return normalized.boxes === 0 && normalized.units === 0;
+}
+
+export function formatQuantity(quantity, { compact = false } = {}) {
+  const { boxes, units } = ensureQuantity(quantity);
+  if (compact) {
+    return `${boxes}c / ${units}u`;
+  }
+  return `${boxes} cajas · ${units} unidades`;
+}


### PR DESCRIPTION
## Summary
- refactor stock-related MongoDB models and service logic to store quantities as boxes and units
- validate and normalize movement request payloads and responses with the new quantity structure
- refresh item forms, dashboards, reports, and customer views to capture and display stock and reservations by boxes and units, adding a reusable quantity helper

## Testing
- npm test (backend)
- npm run lint (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68dfd1f60e00832aa795db4c62d6dbc9