### PR TITLE
Allow resubmitting rejected movement requests

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -48,6 +48,10 @@ paths:
     post:
       summary: Request a stock movement (requires auth)
       responses: { '201': { description: Created } }
+  /api/stock/request/{requestId}/resubmit:
+    post:
+      summary: Resubmit a rejected movement request
+      responses: { '200': { description: Resubmitted } }
   /api/stock/approve/{requestId}:
     post:
       summary: Approve and execute movement (Admin)


### PR DESCRIPTION
## Summary
- add an API endpoint to resubmit rejected movement requests and log the action
- surface a "Reenviar" action in the movement request history for rejected entries
- document the new endpoint in the OpenAPI specification

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e00d63fa98832aa850f19ed2dcb5d3