### PR TITLE
Agregar política de SKU y script de sincronización (`sku:sync`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,16 @@ Al primer arranque se crean los roles `Administrador`, `Operador` y `Consulta`, 
 
 Se recomienda cambiar la contraseña apenas se acceda al sistema y ajustar los permisos según la operación real.
 
+### Política de SKU de artículos
+
+El backend genera SKU automáticamente para artículos nuevos y también completa SKU faltantes en artículos existentes:
+
+- **Formato**: numérico de 6 dígitos con ceros a la izquierda (por ejemplo `000123`).
+- **Nuevos artículos**: al crear un artículo, si no se envía SKU, se reserva el siguiente valor correlativo y se persiste junto al documento.
+- **Artículos existentes sin SKU**: en cada arranque del backend se sincroniza el contador con el mayor SKU existente y luego se hace un *backfill* de artículos que no tienen SKU (`null`, vacío o inexistente), asignando valores correlativos.
+- **Cuándo se ejecuta la actualización**: en `npm start`/`npm run dev` se ejecuta durante el arranque del backend. Si importas productos con el servidor ya levantado, puedes forzarla manualmente con `npm run sku:sync`.
+- **Persistencia y restricciones**: el campo `sku` queda guardado en MongoDB, es único y marcado como inmutable en el modelo (`immutable: true`), por lo que no debería modificarse luego del alta.
+
 ### Datos de ejemplo
 
 En `backend/docs/sample-dataset.json` se incluye un juego de datos genérico que cubre roles, usuarios, grupos, artículos, depósitos,

--- a/backend/package.json
+++ b/backend/package.json
@@ -7,7 +7,8 @@
     "start": "node src/index.js",
     "dev": "nodemon src/index.js",
     "test": "node -e \"console.log('No hay pruebas automatizadas definidas')\"",
-    "seed:sample": "node scripts/import-sample-dataset.js"
+    "seed:sample": "node scripts/import-sample-dataset.js",
+    "sku:sync": "node scripts/sync-item-skus.js"
   },
   "keywords": [],
   "author": "",

--- a/backend/scripts/sync-item-skus.js
+++ b/backend/scripts/sync-item-skus.js
@@ -1,0 +1,18 @@
+const mongoose = require('mongoose');
+const { connectDatabase } = require('../src/db');
+const { ensureItemSkus } = require('../src/services/skuService');
+
+async function main() {
+  try {
+    await connectDatabase();
+    await ensureItemSkus();
+    console.log('Sincronización de SKU completada.');
+  } catch (error) {
+    console.error('No se pudo sincronizar SKU de artículos.', error);
+    process.exitCode = 1;
+  } finally {
+    await mongoose.connection.close();
+  }
+}
+
+main();


### PR DESCRIPTION
### Motivation

- Documentar el comportamiento del backend respecto a la generación y llenado de SKU para artículos. 
- Proveer una forma operativa de sincronizar y backfillear SKUs en instancias existentes mediante un script reutilizable. 
- Exponer la herramienta de sincronización como un script de npm para facilitar su ejecución en entornos de desarrollo y despliegue.

### Description

- Se añadió la sección "Política de SKU de artículos" en `README.md` describiendo formato, comportamiento en creación, backfill en arranque, ejecución manual y restricciones de persistencia. 
- Se agregó el script de utilidad `backend/scripts/sync-item-skus.js` que conecta a la base de datos, invoca `ensureItemSkus` desde `src/services/skuService` y cierra la conexión. 
- Se registró un nuevo comando npm `sku:sync` en `backend/package.json` que ejecuta el script de sincronización. 
- No se cambió la lógica de `ensureItemSkus` en este PR; el script reutiliza el servicio existente para realizar la sincronización.

### Testing

- No hay pruebas automatizadas definidas en el proyecto; ejecutar `npm test` imprime `No hay pruebas automatizadas definidas`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69deb3352d1c832aa53a41faf3610a2e)