### PR TITLE
Add automatic SKU policy, sync script and ensure SKUs on item listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,17 @@ Al primer arranque se crean los roles `Administrador`, `Operador` y `Consulta`, 
 
 Se recomienda cambiar la contraseña apenas se acceda al sistema y ajustar los permisos según la operación real.
 
+### Política de SKU de artículos
+
+El backend genera SKU automáticamente para artículos nuevos y también completa SKU faltantes en artículos existentes:
+
+- **Formato**: numérico de 6 dígitos con ceros a la izquierda (por ejemplo `000123`).
+- **Nuevos artículos**: al crear un artículo, si no se envía SKU, se reserva el siguiente valor correlativo y se persiste junto al documento.
+- **Artículos existentes sin SKU**: en cada arranque del backend se sincroniza el contador con el mayor SKU existente y luego se hace un *backfill* de artículos que no tienen SKU (`null`, vacío o inexistente), asignando valores correlativos.
+- **Cuándo se ejecuta la actualización**: en `npm start`/`npm run dev` se ejecuta durante el arranque del backend. Si importas productos con el servidor ya levantado, puedes forzarla manualmente con `npm run sku:sync`.
+- **Desde dónde correrlo**: ejecútalo dentro de la carpeta `backend/` (`cd backend && npm run sku:sync`) o desde la raíz con `npm --prefix backend run sku:sync`.
+- **Persistencia y restricciones**: el campo `sku` queda guardado en MongoDB, es único y marcado como inmutable en el modelo (`immutable: true`), por lo que no debería modificarse luego del alta.
+
 ### Datos de ejemplo
 
 En `backend/docs/sample-dataset.json` se incluye un juego de datos genérico que cubre roles, usuarios, grupos, artículos, depósitos,

--- a/backend/package.json
+++ b/backend/package.json
@@ -7,7 +7,8 @@
     "start": "node src/index.js",
     "dev": "nodemon src/index.js",
     "test": "node -e \"console.log('No hay pruebas automatizadas definidas')\"",
-    "seed:sample": "node scripts/import-sample-dataset.js"
+    "seed:sample": "node scripts/import-sample-dataset.js",
+    "sku:sync": "node scripts/sync-item-skus.js"
   },
   "keywords": [],
   "author": "",

--- a/backend/scripts/sync-item-skus.js
+++ b/backend/scripts/sync-item-skus.js
@@ -1,0 +1,18 @@
+const mongoose = require('mongoose');
+const { connectDatabase } = require('../src/db');
+const { ensureItemSkus } = require('../src/services/skuService');
+
+async function main() {
+  try {
+    await connectDatabase();
+    await ensureItemSkus();
+    console.log('Sincronización de SKU completada.');
+  } catch (error) {
+    console.error('No se pudo sincronizar SKU de artículos.', error);
+    process.exitCode = 1;
+  } finally {
+    await mongoose.connection.close();
+  }
+}
+
+main();

--- a/backend/src/routes/items.js
+++ b/backend/src/routes/items.js
@@ -11,7 +11,7 @@ const Group = require('../models/Group');
 const { normalizeQuantityInput } = require('../services/stockService');
 const { recordAuditEvent } = require('../services/auditService');
 const { collectGroupAndDescendantIds, buildGroupFilterValues } = require('../services/groupService');
-const { assignSkuToNewItemData } = require('../services/skuService');
+const { assignSkuToNewItemData, ensureItemSkus } = require('../services/skuService');
 
 const { promises: fsPromises } = fs;
 
@@ -388,6 +388,13 @@ router.get(
   '/',
   requirePermission('items.read'),
   asyncHandler(async (req, res) => {
+    const hasMissingSku = await Item.exists({
+      $or: [{ sku: { $exists: false } }, { sku: null }, { sku: '' }]
+    });
+    if (hasMissingSku) {
+      await ensureItemSkus();
+    }
+
     const { page = '1', pageSize = '20', groupId, search, gender, size, color } = req.query || {};
     const pageNumber = Math.max(parseInt(page, 10) || 1, 1);
     const limit = Math.min(Math.max(parseInt(pageSize, 10) || 20, 1), 200);

--- a/backend/src/services/skuService.js
+++ b/backend/src/services/skuService.js
@@ -55,7 +55,7 @@ async function backfillMissingSkus() {
 
   for (const item of missingItems) {
     const nextValue = await reserveNextSkuValue();
-    await Item.updateOne(
+    await Item.collection.updateOne(
       {
         _id: item._id,
         $or: [{ sku: { $exists: false } }, { sku: null }, { sku: '' }]


### PR DESCRIPTION
### Motivation

- Provide a consistent SKU policy and automatic population for items to avoid missing or duplicate SKUs and to support imports and incremental creation. 

### Description

- Add documentation for the SKU policy and usage to `README.md` describing format, backfill behavior, and how to run the sync. 
- Add a `sku:sync` npm script and new script `backend/scripts/sync-item-skus.js` that invokes the SKU synchronization routine. 
- Update `backend/src/routes/items.js` to detect missing SKUs on item listing and run `ensureItemSkus()` to backfill lazily at runtime. 
- Improve `skuService` backfill logic to use `Item.collection.updateOne` for the conditional update and export `ensureItemSkus` for reuse. 

### Testing

- Ran the repository `npm test` automated script which prints the project test placeholder message and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69deb3352d1c832aa53a41faf3610a2e)