### PR TITLE
Agregar filtro por SKU en búsqueda de artículos

### DIFF
--- a/backend/src/routes/items.js
+++ b/backend/src/routes/items.js
@@ -395,7 +395,7 @@ router.get(
       await ensureItemSkus();
     }
 
-    const { page = '1', pageSize = '20', groupId, search, gender, size, color } = req.query || {};
+    const { page = '1', pageSize = '20', groupId, search, sku, gender, size, color } = req.query || {};
     const pageNumber = Math.max(parseInt(page, 10) || 1, 1);
     const limit = Math.min(Math.max(parseInt(pageSize, 10) || 20, 1), 200);
     const filter = {};
@@ -419,6 +419,9 @@ router.get(
     if (search) {
       const regex = new RegExp(search, 'i');
       filter.$or = [{ code: regex }, { description: regex }];
+    }
+    if (typeof sku === 'string' && sku.trim()) {
+      filter.sku = new RegExp(escapeRegex(sku.trim()), 'i');
     }
     const [total, items] = await Promise.all([
       Item.countDocuments(filter),

--- a/frontend/src/pages/items/ItemsPage.jsx
+++ b/frontend/src/pages/items/ItemsPage.jsx
@@ -183,7 +183,7 @@ export default function ItemsPage() {
   const [groups, setGroups] = useState([]);
   const [locations, setLocations] = useState([]);
   const [pendingSnapshot, setPendingSnapshot] = useState([]);
-  const [filters, setFilters] = useState({ search: '', groupId: '', gender: '', size: '', color: '' });
+  const [filters, setFilters] = useState({ search: '', sku: '', groupId: '', gender: '', size: '', color: '' });
   const [formValues, setFormValues] = useState({
     code: '',
     description: '',
@@ -328,6 +328,7 @@ export default function ItemsPage() {
           page,
           pageSize,
           search: filters.search,
+          sku: filters.sku,
           groupId: filters.groupId,
           gender: filters.gender,
           size: filters.size,
@@ -359,6 +360,7 @@ export default function ItemsPage() {
     filters.gender,
     filters.groupId,
     filters.search,
+    filters.sku,
     filters.size,
     page,
     pageSize,
@@ -1180,6 +1182,18 @@ export default function ItemsPage() {
                 );
               })}
             </select>
+          </div>
+          <div className="input-group">
+            <label htmlFor="filterSku">SKU</label>
+            <input
+              id="filterSku"
+              value={filters.sku}
+              onChange={event => {
+                setFilters(prev => ({ ...prev, sku: event.target.value }));
+                setPage(1);
+              }}
+              placeholder="SKU"
+            />
           </div>
           <div className="input-group">
             <label htmlFor="filterGender">Género</label>


### PR DESCRIPTION
### Motivation
- Permitir búsquedas específicas por SKU en la pantalla de artículos para no depender solo del campo general de búsqueda por código/descripcion.

### Description
- Frontend: se añadió `sku` al estado `filters`, un input `SKU` en el formulario de búsqueda y se incluye `sku` en la query enviada a `GET /items`, además de agregar `filters.sku` a las dependencias del `useEffect` que carga la lista (`frontend/src/pages/items/ItemsPage.jsx`).
- Backend: se admite el query param `sku` en `GET /items` y se aplica un filtro de coincidencia parcial case-insensitive sobre el campo `sku` usando `escapeRegex` para evitar problemas con metacaracteres (`backend/src/routes/items.js`).

### Testing
- Ejecutado `npm --prefix backend test`, que corrió el script de pruebas definido y finalizó correctamente.
- Ejecutado `npm --prefix frontend run build` y la compilación de producción de la UI se completó con éxito.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df732262d4832a9969b3c1f3beedf1)