### PR TITLE
Agregar scripts de gestión de SKU, sincronizar contador al asignar SKU y documentar la política

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,18 @@ Al primer arranque se crean los roles `Administrador`, `Operador` y `Consulta`, 
 
 Se recomienda cambiar la contraseña apenas se acceda al sistema y ajustar los permisos según la operación real.
 
+### Política de SKU de artículos
+
+El backend genera SKU automáticamente para artículos nuevos y también completa SKU faltantes en artículos existentes:
+
+- **Formato**: numérico de 6 dígitos con ceros a la izquierda (por ejemplo `000123`).
+- **Nuevos artículos**: al crear un artículo, si no se envía SKU, se sincroniza el contador contra el SKU más alto existente y luego se reserva el siguiente correlativo.
+- **Sin auto-backfill en arranque/listados**: no se ejecutan actualizaciones automáticas de SKU al iniciar el servidor ni al consultar listados.
+- **Backfill manual (si lo necesitas)**: ejecuta `npm run sku:sync` (o `npm --prefix backend run sku:sync`) para completar SKU faltantes en artículos existentes.
+- **Por qué pueden verse SKU “altos” (ej. `031800`)**: el sistema siempre continúa desde el mayor SKU existente para evitar duplicados. Puedes revisar el estado actual con `npm run sku:status` (o `npm --prefix backend run sku:status`).
+- **Si quieres reiniciar desde `000001`**: ejecuta `npm run sku:reindex` (o `npm --prefix backend run sku:reindex`). Este comando **reasigna TODOS los SKU** de forma correlativa según `createdAt` + `_id` y deja el contador ajustado al total de artículos.
+- **Persistencia y restricciones**: el campo `sku` queda guardado en MongoDB, es único y marcado como inmutable en el modelo (`immutable: true`), por lo que no debería modificarse luego del alta.
+
 ### Datos de ejemplo
 
 En `backend/docs/sample-dataset.json` se incluye un juego de datos genérico que cubre roles, usuarios, grupos, artículos, depósitos,

--- a/backend/package.json
+++ b/backend/package.json
@@ -7,7 +7,10 @@
     "start": "node src/index.js",
     "dev": "nodemon src/index.js",
     "test": "node -e \"console.log('No hay pruebas automatizadas definidas')\"",
-    "seed:sample": "node scripts/import-sample-dataset.js"
+    "seed:sample": "node scripts/import-sample-dataset.js",
+    "sku:sync": "node scripts/sync-item-skus.js",
+    "sku:status": "node scripts/sku-status.js",
+    "sku:reindex": "node scripts/reindex-item-skus.js"
   },
   "keywords": [],
   "author": "",

--- a/backend/scripts/reindex-item-skus.js
+++ b/backend/scripts/reindex-item-skus.js
@@ -1,0 +1,50 @@
+const mongoose = require('mongoose');
+const { connectDatabase } = require('../src/db');
+const Counter = require('../src/models/Counter');
+const Item = require('../src/models/Item');
+const { formatSku } = require('../src/services/skuService');
+
+async function main() {
+  try {
+    await connectDatabase();
+
+    const items = await Item.find({})
+      .sort({ createdAt: 1, _id: 1 })
+      .select({ _id: 1 })
+      .lean();
+
+    if (items.length === 0) {
+      await Counter.findOneAndUpdate(
+        { key: 'item_sku' },
+        { $set: { value: 0 } },
+        { upsert: true, setDefaultsOnInsert: true }
+      );
+      console.log('No hay artículos. Contador SKU reiniciado en 0.');
+      return;
+    }
+
+    const operations = items.map((item, index) => ({
+      updateOne: {
+        filter: { _id: item._id },
+        update: { $set: { sku: formatSku(index + 1) } }
+      }
+    }));
+
+    await Item.collection.bulkWrite(operations, { ordered: true });
+    await Counter.findOneAndUpdate(
+      { key: 'item_sku' },
+      { $set: { value: items.length } },
+      { upsert: true, setDefaultsOnInsert: true }
+    );
+
+    console.log(`Reindexación SKU completada. Total de artículos: ${items.length}.`);
+    console.log(`Rango asignado: 000001 a ${formatSku(items.length)}.`);
+  } catch (error) {
+    console.error('No se pudo reindexar SKU de artículos.', error);
+    process.exitCode = 1;
+  } finally {
+    await mongoose.connection.close();
+  }
+}
+
+main();

--- a/backend/scripts/sku-status.js
+++ b/backend/scripts/sku-status.js
@@ -1,0 +1,35 @@
+const mongoose = require('mongoose');
+const { connectDatabase } = require('../src/db');
+const Counter = require('../src/models/Counter');
+const Item = require('../src/models/Item');
+
+async function main() {
+  try {
+    await connectDatabase();
+
+    const counter = await Counter.findOne({ key: 'item_sku' }).lean();
+    const [maxSkuEntry] = await Item.aggregate([
+      { $match: { sku: { $type: 'string', $regex: /^\d{6}$/ } } },
+      { $addFields: { skuNumber: { $toInt: '$sku' } } },
+      { $sort: { skuNumber: -1 } },
+      { $limit: 1 },
+      { $project: { sku: 1, skuNumber: 1 } }
+    ]);
+    const missingSkuCount = await Item.countDocuments({
+      $or: [{ sku: { $exists: false } }, { sku: null }, { sku: '' }]
+    });
+
+    console.log('Estado SKU');
+    console.log('----------');
+    console.log(`Counter item_sku: ${counter?.value ?? 0}`);
+    console.log(`Máximo SKU en items: ${maxSkuEntry?.sku || 'N/A'} (${maxSkuEntry?.skuNumber || 0})`);
+    console.log(`Items sin SKU: ${missingSkuCount}`);
+  } catch (error) {
+    console.error('No se pudo obtener el estado de SKU.', error);
+    process.exitCode = 1;
+  } finally {
+    await mongoose.connection.close();
+  }
+}
+
+main();

--- a/backend/scripts/sync-item-skus.js
+++ b/backend/scripts/sync-item-skus.js
@@ -1,0 +1,18 @@
+const mongoose = require('mongoose');
+const { connectDatabase } = require('../src/db');
+const { ensureItemSkus } = require('../src/services/skuService');
+
+async function main() {
+  try {
+    await connectDatabase();
+    await ensureItemSkus();
+    console.log('Sincronización de SKU completada.');
+  } catch (error) {
+    console.error('No se pudo sincronizar SKU de artículos.', error);
+    process.exitCode = 1;
+  } finally {
+    await mongoose.connection.close();
+  }
+}
+
+main();

--- a/backend/src/seed.js
+++ b/backend/src/seed.js
@@ -4,7 +4,6 @@ const User = require('./models/User');
 const Group = require('./models/Group');
 const config = require('./config');
 const Location = require('./models/Location');
-const { ensureItemSkus } = require('./services/skuService');
 
 const defaultRoles = [
   {
@@ -114,7 +113,6 @@ async function seed() {
   await seedGroups();
   await seedLocations();
   await seedAdminUser();
-  await ensureItemSkus();
 }
 
 module.exports = seed;

--- a/backend/src/services/skuService.js
+++ b/backend/src/services/skuService.js
@@ -24,6 +24,7 @@ async function assignSkuToNewItemData(itemData, { session } = {}) {
   if (itemData.sku) {
     return itemData;
   }
+  await syncSkuCounterWithExistingItems();
   const nextValue = await reserveNextSkuValue({ session });
   return { ...itemData, sku: formatSku(nextValue) };
 }
@@ -55,7 +56,7 @@ async function backfillMissingSkus() {
 
   for (const item of missingItems) {
     const nextValue = await reserveNextSkuValue();
-    await Item.updateOne(
+    await Item.collection.updateOne(
       {
         _id: item._id,
         $or: [{ sku: { $exists: false } }, { sku: null }, { sku: '' }]


### PR DESCRIPTION
### Motivation

- Centralizar la política de generación de SKU y proporcionar utilidades para inspeccionar, sincronizar y reindexar SKUs sin ejecutar backfills automáticos en el arranque.

### Description

- Se agregó la sección "Política de SKU de artículos" a `README.md` explicando formato, comportamiento al crear artículos y comandos disponibles. 
- Se añadieron los scripts de mantenimiento y entradas en `backend/package.json`: `sku:sync`, `sku:status` y `sku:reindex`, con sus implementaciones en `backend/scripts/sync-item-skus.js`, `backend/scripts/sku-status.js` y `backend/scripts/reindex-item-skus.js` respectivamente. 
- Se modificó `backend/src/services/skuService.js` para incluir `syncSkuCounterWithExistingItems()` y llamar a esta función desde `assignSkuToNewItemData()` para alinear el contador con el mayor SKU existente antes de reservar el siguiente valor, y se cambió el backfill para usar `Item.collection.updateOne` en lugar de `Item.updateOne`. 
- Se eliminó la ejecución automática de `ensureItemSkus()` desde `backend/src/seed.js` para evitar backfills en el proceso de seed/arranque.

### Testing

- Se ejecutó `npm test`, que imprime `No hay pruebas automatizadas definidas` y finaliza correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69deb3352d1c832aa53a41faf3610a2e)