### PR TITLE
Ajusta orden y ancho de filtros en la búsqueda de artículos

### DIFF
--- a/frontend/src/pages/items/ItemsPage.jsx
+++ b/frontend/src/pages/items/ItemsPage.jsx
@@ -1319,7 +1319,19 @@ export default function ItemsPage() {
             {printing ? 'Preparando impresión…' : 'Imprimir filtrados'}
           </button>
         </div>
-        <form className="form-grid" style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))' }}>
+        <form className="form-grid" style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(126px, 1fr))' }}>
+          <div className="input-group">
+            <label htmlFor="filterSku">SKU</label>
+            <input
+              id="filterSku"
+              value={filters.sku}
+              onChange={event => {
+                setFilters(prev => ({ ...prev, sku: event.target.value }));
+                setPage(1);
+              }}
+              placeholder="SKU"
+            />
+          </div>
           <div className="input-group">
             <label htmlFor="search">Buscar</label>
             <input
@@ -1352,18 +1364,6 @@ export default function ItemsPage() {
                 );
               })}
             </select>
-          </div>
-          <div className="input-group">
-            <label htmlFor="filterSku">SKU</label>
-            <input
-              id="filterSku"
-              value={filters.sku}
-              onChange={event => {
-                setFilters(prev => ({ ...prev, sku: event.target.value }));
-                setPage(1);
-              }}
-              placeholder="SKU"
-            />
           </div>
           <div className="input-group">
             <label htmlFor="filterGender">Género</label>


### PR DESCRIPTION
### Motivation
- Mejorar la usabilidad del panel de filtros en la página de artículos poniendo el filtro `SKU` primero (izquierda) para acceso rápido.
- Permitir que más filtros quepan en la misma fila reduciendo el ancho base de cada filtro en un 30% ajustando el `minmax` del grid. 

### Description
- Se modificó `frontend/src/pages/items/ItemsPage.jsx` para mover el campo `SKU` al inicio del formulario de búsqueda y actualizar su `id`, `value` y el manejador de cambio (`filters.sku`).
- Se cambió el estilo del grid de filtros de `gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))'` a `gridTemplateColumns: 'repeat(auto-fit, minmax(126px, 1fr))'` para reducir el ancho base de cada filtro.
- Se reordenaron los inputs del formulario conservando la lógica de los campos `search`, `groupId`, `gender`, `size` y `color` sin otros cambios funcionales.

### Testing
- Se ejecutó `npm --prefix frontend run build` y la compilación de producción de la aplicación frontend finalizó correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df7abeaa74832ab8b390b3cff2d89a)