### PR TITLE
Agregar campo de filtro por SKU en Buscar artículos

### DIFF
--- a/frontend/src/pages/items/ItemsPage.jsx
+++ b/frontend/src/pages/items/ItemsPage.jsx
@@ -1331,6 +1331,18 @@ export default function ItemsPage() {
         </div>
         <form className="form-grid" style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))' }}>
           <div className="input-group">
+            <label htmlFor="filterSku">SKU</label>
+            <input
+              id="filterSku"
+              value={filters.sku}
+              onChange={event => {
+                setFilters(prev => ({ ...prev, sku: event.target.value }));
+                setPage(1);
+              }}
+              placeholder="Filtrar por SKU"
+            />
+          </div>
+          <div className="input-group">
             <label htmlFor="search">Buscar</label>
             <input
               id="search"


### PR DESCRIPTION
### Motivation
- Exponer el filtro por SKU en la UI de búsqueda para que los usuarios puedan filtrar explícitamente por `filters.sku` y priorizar la búsqueda por SKU.

### Description
- Se añadió un input de texto al inicio del formulario de búsqueda en `frontend/src/pages/items/ItemsPage.jsx` con `id="filterSku"` que actualiza `filters.sku` y llama a `setPage(1)` al cambiar.

### Testing
- Ejecutado `npm run build` en la carpeta `frontend` y la compilación de producción completó correctamente. ✅

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df90aca324832aa4ad442a899e8432)