### PR TITLE
Ajusta columnas del listado imprimible de artículos seleccionados

### DIFF
--- a/frontend/src/pages/items/ItemsPage.jsx
+++ b/frontend/src/pages/items/ItemsPage.jsx
@@ -955,37 +955,11 @@ export default function ItemsPage() {
 
       const tableRows = collectedItems
         .map(item => {
-          const precioBase =
-            item.precio !== null && item.precio !== undefined
-              ? item.precio
-              : item.pDecimal !== null && item.pDecimal !== undefined
-                ? item.pDecimal
-                : null;
-
-          const attributesText = Object.entries(item.attributes || {})
-            .map(([key, value]) => `${key}: ${value}`)
-            .join(', ');
-
           return `
             <tr>
               <td>${escapeHtml(item.sku || '-')}</td>
               <td>${escapeHtml(item.code || '-')}</td>
               <td>${escapeHtml(item.description || '-')}</td>
-              <td>${escapeHtml(item.groupName || 'Sin grupo')}</td>
-              <td>${
-                precioBase === null
-                  ? '-'
-                  : escapeHtml(
-                      Number(precioBase).toLocaleString('es-AR', {
-                        minimumFractionDigits: 2,
-                        maximumFractionDigits: 2
-                      })
-                    )
-              }</td>
-              <td>${escapeHtml(attributesText || '-')}</td>
-              <td>${escapeHtml(
-                item.unitsPerBox === null || item.unitsPerBox === undefined ? '-' : String(item.unitsPerBox)
-              )}</td>
             </tr>
           `;
         })
@@ -1022,16 +996,12 @@ export default function ItemsPage() {
                   <th>SKU</th>
                   <th>Código</th>
                   <th>Descripción</th>
-                  <th>Grupo</th>
-                  <th>Precio</th>
-                  <th>Atributos</th>
-                  <th>Unidades por caja</th>
                 </tr>
               </thead>
               <tbody>
                 ${
                   tableRows ||
-                  '<tr><td colspan="7" style="text-align:center">No hay artículos seleccionados para imprimir.</td></tr>'
+                  '<tr><td colspan="3" style="text-align:center">No hay artículos seleccionados para imprimir.</td></tr>'
                 }
               </tbody>
             </table>


### PR DESCRIPTION
### Motivation
- Simplificar el PDF/HTML imprimible del listado de artículos seleccionados para mostrar únicamente las columnas requeridas: SKU, Código y Descripción.

### Description
- Se actualizó `frontend/src/pages/items/ItemsPage.jsx` para eliminar las columnas y celdas de Grupo, Precio, Atributos y Unidades por caja en el contenido imprimible.
- Se removió el cálculo de `precioBase` y la generación de `attributesText` que ya no se usan en la tabla.
- Se ajustaron las filas generadas (`tableRows`) para renderizar solo tres celdas: SKU, Código y Descripción.
- Se actualizó el `colspan` del mensaje de tabla vacía a `3` para coincidir con el nuevo número de columnas.

### Testing
- Ejecuté `npm --prefix frontend run lint` y el script se completó correctamente (el proyecto indica que no hay reglas de lint configuradas).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfa50c3dd0832a926a4a022f2b196f)