### PR TITLE
Actualizar textos de selección de PDF a 'Descargar' en ItemsPage

### DIFF
--- a/frontend/src/pages/items/ItemsPage.jsx
+++ b/frontend/src/pages/items/ItemsPage.jsx
@@ -1516,10 +1516,10 @@ export default function ItemsPage() {
         <div className="flex-between" style={{ marginTop: '0.75rem', gap: '0.75rem', alignItems: 'center' }}>
           <div>
             <span style={{ color: '#475569', fontSize: '0.9rem' }}>
-              Seleccionados para PDF: <strong>{selectedItemsList.length}</strong>
+              Seleccionados para descarga: <strong>{selectedItemsList.length}</strong>
             </span>
             <p style={{ margin: '0.15rem 0 0', color: '#64748b', fontSize: '0.78rem' }}>
-              Podés marcar artículo por artículo con el check de cada línea (columna PDF).
+              Podés marcar artículo por artículo con el check de cada línea (columna Descargar).
             </p>
           </div>
           <div className="inline-actions">
@@ -1557,7 +1557,7 @@ export default function ItemsPage() {
               <thead>
                 <tr>
                   <th>
-                    PDF (línea)
+                    Descargar
                   </th>
                   <th>SKU</th>
                   <th>Código</th>


### PR DESCRIPTION
### Motivation
- Unificar y aclarar la terminología de la interfaz para que refleje la acción de descarga en lugar de "PDF".
- Mejorar la ayuda contextual para que los usuarios identifiquen correctamente la columna de selección por línea.
- Evitar confusión entre la etiqueta visual y la acción real disponible en la vista de ítems.

### Description
- Reemplacé el texto `Seleccionados para PDF` por `Seleccionados para descarga` en `frontend/src/pages/items/ItemsPage.jsx`.
- Actualicé la ayuda contextual `Podés marcar artículo por artículo con el check de cada línea (columna PDF).` a `columna Descargar` en el mismo archivo.
- Cambié el encabezado de la columna de la tabla de `PDF (línea)` a `Descargar` en `frontend/src/pages/items/ItemsPage.jsx`.

### Testing
- Ejecuté `git diff --check` y no reportó errores.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfa5656cc8832a9962ed50d8e46df6)