### PR TITLE
Add EAN13 barcode SVG generation and A4 label printing to ItemsDownloadPage

### DIFF
--- a/frontend/src/pages/items/ItemsDownloadPage.jsx
+++ b/frontend/src/pages/items/ItemsDownloadPage.jsx
@@ -105,6 +105,96 @@ function escapeHtml(value) {
     .replaceAll("'", '&#39;');
 }
 
+const EAN13_LEFT_PARITY_BY_FIRST_DIGIT = {
+  0: 'LLLLLL',
+  1: 'LLGLGG',
+  2: 'LLGGLG',
+  3: 'LLGGGL',
+  4: 'LGLLGG',
+  5: 'LGGLLG',
+  6: 'LGGGLL',
+  7: 'LGLGLG',
+  8: 'LGLGGL',
+  9: 'LGGLGL'
+};
+
+const EAN13_L_PATTERNS = ['0001101', '0011001', '0010011', '0111101', '0100011', '0110001', '0101111', '0111011', '0110111', '0001011'];
+const EAN13_G_PATTERNS = ['0100111', '0110011', '0011011', '0100001', '0011101', '0111001', '0000101', '0010001', '0001001', '0010111'];
+const EAN13_R_PATTERNS = ['1110010', '1100110', '1101100', '1000010', '1011100', '1001110', '1010000', '1000100', '1001000', '1110100'];
+
+function sanitizeEan13(ean) {
+  if (typeof ean !== 'string') {
+    return '';
+  }
+  const digits = ean.replace(/\D/g, '');
+  return digits.length === 13 ? digits : '';
+}
+
+function buildEan13Binary(ean13) {
+  const sanitized = sanitizeEan13(ean13);
+  if (!sanitized) {
+    return null;
+  }
+  const firstDigit = Number(sanitized[0]);
+  const parity = EAN13_LEFT_PARITY_BY_FIRST_DIGIT[firstDigit];
+  if (!parity) {
+    return null;
+  }
+
+  let binary = '101';
+  for (let index = 1; index <= 6; index += 1) {
+    const digit = Number(sanitized[index]);
+    binary += parity[index - 1] === 'L' ? EAN13_L_PATTERNS[digit] : EAN13_G_PATTERNS[digit];
+  }
+  binary += '01010';
+  for (let index = 7; index <= 12; index += 1) {
+    const digit = Number(sanitized[index]);
+    binary += EAN13_R_PATTERNS[digit];
+  }
+  binary += '101';
+  return binary;
+}
+
+function buildEan13SvgMarkup(ean13) {
+  const binary = buildEan13Binary(ean13);
+  if (!binary) {
+    return `<div class="barcode-error">EAN inválido</div>`;
+  }
+  const moduleWidth = 1;
+  const quietZoneModules = 9;
+  const totalModules = binary.length + quietZoneModules * 2;
+  const guardBarHeight = 62;
+  const normalBarHeight = 56;
+  const viewBoxHeight = 68;
+  let currentX = quietZoneModules;
+  let rects = '';
+
+  for (let index = 0; index < binary.length; index += 1) {
+    if (binary[index] !== '1') {
+      currentX += moduleWidth;
+      continue;
+    }
+    const runStart = currentX;
+    let runLength = 0;
+    while (index < binary.length && binary[index] === '1') {
+      runLength += 1;
+      currentX += moduleWidth;
+      index += 1;
+    }
+    index -= 1;
+
+    const isGuardZone = index < 3 || (index >= 45 && index < 50) || index >= 92;
+    const barHeight = isGuardZone ? guardBarHeight : normalBarHeight;
+    rects += `<rect x="${runStart}" y="0" width="${runLength}" height="${barHeight}" fill="#000"></rect>`;
+  }
+
+  return `
+    <svg class="barcode-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${totalModules} ${viewBoxHeight}" role="img" aria-label="Código EAN ${escapeHtml(ean13)}">
+      ${rects}
+    </svg>
+  `;
+}
+
 export default function ItemsDownloadPage() {
   const api = useApi();
   const { user } = useAuth();
@@ -261,7 +351,7 @@ export default function ItemsDownloadPage() {
     selectVisibleItemsForPrint();
   }, [clearSelectionForPrint, selectVisibleItemsForPrint, visibleSelectionState.allSelected, visibleSelectionState.someSelected]);
 
-  const handlePrintFilteredItems = async () => {
+  const handlePrintFilteredItems = async itemsToPrint => {
     if (printing) return;
     const printWindow = window.open('', '_blank');
     if (!printWindow) {
@@ -292,7 +382,7 @@ export default function ItemsDownloadPage() {
     setPrinting(true);
     setError(null);
     try {
-      const collectedItems = [...selectedItemsList];
+      const collectedItems = Array.isArray(itemsToPrint) ? [...itemsToPrint] : [...selectedItemsList];
       if (collectedItems.length === 0) {
         throw new Error('Seleccioná al menos un artículo para generar el PDF.');
       }
@@ -302,15 +392,15 @@ export default function ItemsDownloadPage() {
         timeStyle: 'short'
       });
 
-      const tableRows = collectedItems
+      const labelCards = collectedItems
         .map(item => {
           return `
-            <tr>
-              <td>${escapeHtml(item.sku || '-')}</td>
-              <td>${escapeHtml(item.ean13 || '-')}</td>
-              <td>${escapeHtml(item.code || '-')}</td>
-              <td>${escapeHtml(item.description || '-')}</td>
-            </tr>
+            <article class="label-card">
+              <div class="barcode-wrap">
+                ${buildEan13SvgMarkup(item.ean13)}
+              </div>
+              <p class="ean-text">${escapeHtml(item.ean13 || '-')}</p>
+            </article>
           `;
         })
         .join('');
@@ -326,11 +416,53 @@ export default function ItemsDownloadPage() {
               h1 { margin: 0 0 8px; font-size: 22px; }
               p { margin: 0 0 6px; color: #334155; }
               .meta { margin-bottom: 14px; }
-              table { width: 100%; border-collapse: collapse; margin-top: 12px; font-size: 12px; }
-              th, td { border: 1px solid #cbd5e1; padding: 8px; text-align: left; vertical-align: top; }
-              th { background: #f8fafc; }
+              .labels-grid {
+                display: grid;
+                grid-template-columns: repeat(3, 63mm);
+                grid-auto-rows: 33.9mm;
+                gap: 2mm;
+                align-content: start;
+              }
+              .label-card {
+                border: 1px dashed #cbd5e1;
+                border-radius: 2mm;
+                padding: 2mm;
+                display: flex;
+                flex-direction: column;
+                justify-content: center;
+                align-items: center;
+                overflow: hidden;
+              }
+              .barcode-wrap { width: 100%; }
+              .barcode-svg {
+                display: block;
+                width: 100%;
+                max-height: 22mm;
+              }
+              .ean-text {
+                margin: 1.8mm 0 0;
+                letter-spacing: 0.5px;
+                font-size: 12px;
+                color: #0f172a;
+                font-weight: 600;
+              }
+              .barcode-error {
+                width: 100%;
+                border: 1px solid #fca5a5;
+                background: #fef2f2;
+                color: #991b1b;
+                font-size: 12px;
+                text-align: center;
+                border-radius: 4px;
+                padding: 8px;
+              }
               @media print {
-                body { margin: 12mm; }
+                @page { size: A4 portrait; margin: 10mm; }
+                body { margin: 0; }
+                .label-card {
+                  break-inside: avoid;
+                  page-break-inside: avoid;
+                }
               }
             </style>
           </head>
@@ -340,22 +472,12 @@ export default function ItemsDownloadPage() {
               <p><strong>Total:</strong> ${collectedItems.length}</p>
               <p><strong>Fecha de impresión:</strong> ${escapeHtml(printedAt)}</p>
             </div>
-            <table>
-              <thead>
-                <tr>
-                  <th>SKU</th>
-                  <th>EAN13</th>
-                  <th>Artículo</th>
-                  <th>Descripción</th>
-                </tr>
-              </thead>
-              <tbody>
-                ${
-                  tableRows ||
-                  '<tr><td colspan="4" style="text-align:center">No hay artículos seleccionados para imprimir.</td></tr>'
-                }
-              </tbody>
-            </table>
+            <section class="labels-grid">
+              ${
+                labelCards ||
+                '<div class="barcode-error">No hay artículos seleccionados para imprimir.</div>'
+              }
+            </section>
           </body>
         </html>
       `;
@@ -398,6 +520,40 @@ export default function ItemsDownloadPage() {
     }
   };
 
+  const handlePrintConfirm = useCallback(
+    itemsToPrint => {
+      const selectedCount = Array.isArray(itemsToPrint) ? itemsToPrint.length : 0;
+      if (selectedCount === 0) {
+        setError(new Error('Seleccioná al menos un artículo para generar etiquetas.'));
+        return;
+      }
+      const confirmed = window.confirm(
+        `Se imprimirán ${selectedCount} etiqueta(s) en formato A4.\n\n¿Deseás continuar?`
+      );
+      if (!confirmed) {
+        return;
+      }
+      handlePrintFilteredItems(itemsToPrint);
+    },
+    [handlePrintFilteredItems]
+  );
+
+  const handlePrintSingleLabel = useCallback(
+    item => {
+      if (!item?.id) return;
+      const singleItemPayload = {
+        id: item.id,
+        sku: item.sku || '-',
+        ean13: buildItemEan13(item.sku, item.unitsPerBox),
+        code: item.code || '-',
+        description: item.description || '-'
+      };
+      setSelectedItemsForPrint(prev => ({ ...prev, [item.id]: singleItemPayload }));
+      handlePrintConfirm([singleItemPayload]);
+    },
+    [handlePrintConfirm]
+  );
+
   if (!canRead) {
     return <ErrorMessage error={new Error('No tenés permisos para ver esta sección.')} />;
   }
@@ -424,11 +580,11 @@ export default function ItemsDownloadPage() {
           <button
             type="button"
             className="secondary-button"
-            onClick={handlePrintFilteredItems}
+            onClick={() => handlePrintConfirm(selectedItemsList)}
             disabled={printing || selectedItemsList.length === 0}
             title={selectedItemsList.length === 0 ? 'Seleccioná artículos para habilitar la descarga.' : undefined}
           >
-            {printing ? 'Preparando impresión…' : 'Descargar filtrados'}
+            {printing ? 'Preparando impresión…' : 'Imprimir etiquetas A4'}
           </button>
         </div>
         <form className="form-grid" style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))' }}>
@@ -577,6 +733,7 @@ export default function ItemsDownloadPage() {
                   <th>EAN13</th>
                   <th>Artículo</th>
                   <th>Descripción</th>
+                  <th>Etiqueta</th>
                 </tr>
               </thead>
               <tbody>
@@ -596,12 +753,17 @@ export default function ItemsDownloadPage() {
                       <td>{buildItemEan13(item.sku, item.unitsPerBox) || '-'}</td>
                       <td>{item.code}</td>
                       <td>{item.description}</td>
+                      <td>
+                        <button type="button" className="secondary-button" onClick={() => handlePrintSingleLabel(item)}>
+                          Imprimir etiqueta
+                        </button>
+                      </td>
                     </tr>
                   );
                 })}
                 {items.length === 0 && (
                   <tr>
-                    <td colSpan={5} style={{ textAlign: 'center', padding: '1.5rem 0' }}>
+                    <td colSpan={6} style={{ textAlign: 'center', padding: '1.5rem 0' }}>
                       No se encontraron artículos para los filtros seleccionados.
                     </td>
                   </tr>


### PR DESCRIPTION
### Motivation

- Provide a way to print item labels in A4 format directly from the items list. 
- Render EAN13 barcodes as inline SVG so labels include machine-readable codes. 
- Enable printing a single label from a row and a confirmed print flow for bulk labels.

### Description

- Added EAN13 encoding utilities: `sanitizeEan13`, `buildEan13Binary`, `buildEan13SvgMarkup`, plus parity and pattern constants for EAN13 generation. 
- Reworked the print flow by updating `handlePrintFilteredItems` to accept a payload, replacing the old table output with a label grid HTML/CSS layout, and generating barcode SVGs per label. 
- Introduced `handlePrintConfirm` to show a confirmation dialog before printing and `handlePrintSingleLabel` to build a single-item payload and trigger printing from a row button. 
- Updated UI: changed the main action button text to `Imprimir etiquetas A4`, added an `Etiqueta` column with a per-row `Imprimir etiqueta` button, and adjusted table column spans and styles to support the labels grid and error states.

### Testing

- No automated tests were added or modified for this change. 
- Existing frontend linting and unit tests were run locally and completed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8e04ccce0832aa5ac37fb5944d305)