### PR TITLE
Add EAN‑13 barcode SVG generation and A4 label printing for items

### DIFF
--- a/frontend/src/pages/items/ItemsDownloadPage.jsx
+++ b/frontend/src/pages/items/ItemsDownloadPage.jsx
@@ -105,6 +105,96 @@ function escapeHtml(value) {
     .replaceAll("'", '&#39;');
 }
 
+const EAN13_LEFT_PARITY_BY_FIRST_DIGIT = {
+  0: 'LLLLLL',
+  1: 'LLGLGG',
+  2: 'LLGGLG',
+  3: 'LLGGGL',
+  4: 'LGLLGG',
+  5: 'LGGLLG',
+  6: 'LGGGLL',
+  7: 'LGLGLG',
+  8: 'LGLGGL',
+  9: 'LGGLGL'
+};
+
+const EAN13_L_PATTERNS = ['0001101', '0011001', '0010011', '0111101', '0100011', '0110001', '0101111', '0111011', '0110111', '0001011'];
+const EAN13_G_PATTERNS = ['0100111', '0110011', '0011011', '0100001', '0011101', '0111001', '0000101', '0010001', '0001001', '0010111'];
+const EAN13_R_PATTERNS = ['1110010', '1100110', '1101100', '1000010', '1011100', '1001110', '1010000', '1000100', '1001000', '1110100'];
+
+function sanitizeEan13(ean) {
+  if (typeof ean !== 'string') {
+    return '';
+  }
+  const digits = ean.replace(/\D/g, '');
+  return digits.length === 13 ? digits : '';
+}
+
+function buildEan13Binary(ean13) {
+  const sanitized = sanitizeEan13(ean13);
+  if (!sanitized) {
+    return null;
+  }
+  const firstDigit = Number(sanitized[0]);
+  const parity = EAN13_LEFT_PARITY_BY_FIRST_DIGIT[firstDigit];
+  if (!parity) {
+    return null;
+  }
+
+  let binary = '101';
+  for (let index = 1; index <= 6; index += 1) {
+    const digit = Number(sanitized[index]);
+    binary += parity[index - 1] === 'L' ? EAN13_L_PATTERNS[digit] : EAN13_G_PATTERNS[digit];
+  }
+  binary += '01010';
+  for (let index = 7; index <= 12; index += 1) {
+    const digit = Number(sanitized[index]);
+    binary += EAN13_R_PATTERNS[digit];
+  }
+  binary += '101';
+  return binary;
+}
+
+function buildEan13SvgMarkup(ean13) {
+  const binary = buildEan13Binary(ean13);
+  if (!binary) {
+    return `<div class="barcode-error">EAN inválido</div>`;
+  }
+  const moduleWidth = 1;
+  const quietZoneModules = 9;
+  const totalModules = binary.length + quietZoneModules * 2;
+  const guardBarHeight = 62;
+  const normalBarHeight = 56;
+  const viewBoxHeight = 68;
+  let currentX = quietZoneModules;
+  let rects = '';
+
+  for (let index = 0; index < binary.length; index += 1) {
+    if (binary[index] !== '1') {
+      currentX += moduleWidth;
+      continue;
+    }
+    const runStart = currentX;
+    let runLength = 0;
+    while (index < binary.length && binary[index] === '1') {
+      runLength += 1;
+      currentX += moduleWidth;
+      index += 1;
+    }
+    index -= 1;
+
+    const isGuardZone = index < 3 || (index >= 45 && index < 50) || index >= 92;
+    const barHeight = isGuardZone ? guardBarHeight : normalBarHeight;
+    rects += `<rect x="${runStart}" y="0" width="${runLength}" height="${barHeight}" fill="#000"></rect>`;
+  }
+
+  return `
+    <svg class="barcode-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${totalModules} ${viewBoxHeight}" role="img" aria-label="Código EAN ${escapeHtml(ean13)}">
+      ${rects}
+    </svg>
+  `;
+}
+
 export default function ItemsDownloadPage() {
   const api = useApi();
   const { user } = useAuth();
@@ -261,7 +351,7 @@ export default function ItemsDownloadPage() {
     selectVisibleItemsForPrint();
   }, [clearSelectionForPrint, selectVisibleItemsForPrint, visibleSelectionState.allSelected, visibleSelectionState.someSelected]);
 
-  const handlePrintFilteredItems = async () => {
+  const handlePrintLabelsA4 = async itemsToPrint => {
     if (printing) return;
     const printWindow = window.open('', '_blank');
     if (!printWindow) {
@@ -292,9 +382,9 @@ export default function ItemsDownloadPage() {
     setPrinting(true);
     setError(null);
     try {
-      const collectedItems = [...selectedItemsList];
+      const collectedItems = Array.isArray(itemsToPrint) ? [...itemsToPrint] : [...selectedItemsList];
       if (collectedItems.length === 0) {
-        throw new Error('Seleccioná al menos un artículo para generar el PDF.');
+        throw new Error('Seleccioná al menos un artículo para generar etiquetas.');
       }
 
       const printedAt = new Date().toLocaleString('es-AR', {
@@ -302,15 +392,15 @@ export default function ItemsDownloadPage() {
         timeStyle: 'short'
       });
 
-      const tableRows = collectedItems
+      const labelCards = collectedItems
         .map(item => {
           return `
-            <tr>
-              <td>${escapeHtml(item.sku || '-')}</td>
-              <td>${escapeHtml(item.ean13 || '-')}</td>
-              <td>${escapeHtml(item.code || '-')}</td>
-              <td>${escapeHtml(item.description || '-')}</td>
-            </tr>
+            <article class="label-card">
+              <div class="barcode-wrap">
+                ${buildEan13SvgMarkup(item.ean13)}
+              </div>
+              <p class="ean-text">${escapeHtml(item.ean13 || '-')}</p>
+            </article>
           `;
         })
         .join('');
@@ -326,11 +416,53 @@ export default function ItemsDownloadPage() {
               h1 { margin: 0 0 8px; font-size: 22px; }
               p { margin: 0 0 6px; color: #334155; }
               .meta { margin-bottom: 14px; }
-              table { width: 100%; border-collapse: collapse; margin-top: 12px; font-size: 12px; }
-              th, td { border: 1px solid #cbd5e1; padding: 8px; text-align: left; vertical-align: top; }
-              th { background: #f8fafc; }
+              .labels-grid {
+                display: grid;
+                grid-template-columns: repeat(3, 63mm);
+                grid-auto-rows: 33.9mm;
+                gap: 2mm;
+                align-content: start;
+              }
+              .label-card {
+                border: 1px dashed #cbd5e1;
+                border-radius: 2mm;
+                padding: 2mm;
+                display: flex;
+                flex-direction: column;
+                justify-content: center;
+                align-items: center;
+                overflow: hidden;
+              }
+              .barcode-wrap { width: 100%; }
+              .barcode-svg {
+                display: block;
+                width: 100%;
+                max-height: 22mm;
+              }
+              .ean-text {
+                margin: 1.8mm 0 0;
+                letter-spacing: 0.5px;
+                font-size: 12px;
+                color: #0f172a;
+                font-weight: 600;
+              }
+              .barcode-error {
+                width: 100%;
+                border: 1px solid #fca5a5;
+                background: #fef2f2;
+                color: #991b1b;
+                font-size: 12px;
+                text-align: center;
+                border-radius: 4px;
+                padding: 8px;
+              }
               @media print {
-                body { margin: 12mm; }
+                @page { size: A4 portrait; margin: 10mm; }
+                body { margin: 0; }
+                .label-card {
+                  break-inside: avoid;
+                  page-break-inside: avoid;
+                }
               }
             </style>
           </head>
@@ -340,22 +472,12 @@ export default function ItemsDownloadPage() {
               <p><strong>Total:</strong> ${collectedItems.length}</p>
               <p><strong>Fecha de impresión:</strong> ${escapeHtml(printedAt)}</p>
             </div>
-            <table>
-              <thead>
-                <tr>
-                  <th>SKU</th>
-                  <th>EAN13</th>
-                  <th>Artículo</th>
-                  <th>Descripción</th>
-                </tr>
-              </thead>
-              <tbody>
-                ${
-                  tableRows ||
-                  '<tr><td colspan="4" style="text-align:center">No hay artículos seleccionados para imprimir.</td></tr>'
-                }
-              </tbody>
-            </table>
+            <section class="labels-grid">
+              ${
+                labelCards ||
+                '<div class="barcode-error">No hay artículos seleccionados para imprimir.</div>'
+              }
+            </section>
           </body>
         </html>
       `;
@@ -398,6 +520,142 @@ export default function ItemsDownloadPage() {
     }
   };
 
+  const handlePrintConfirm = useCallback(
+    itemsToPrint => {
+      const selectedCount = Array.isArray(itemsToPrint) ? itemsToPrint.length : 0;
+      if (selectedCount === 0) {
+        setError(new Error('Seleccioná al menos un artículo para generar etiquetas.'));
+        return;
+      }
+      const confirmed = window.confirm(
+        `Se imprimirán ${selectedCount} etiqueta(s) en formato A4.\n\n¿Deseás continuar?`
+      );
+      if (!confirmed) {
+        return;
+      }
+      handlePrintLabelsA4(itemsToPrint);
+    },
+    [handlePrintLabelsA4]
+  );
+
+  const handlePrintSingleLabel = useCallback(
+    item => {
+      if (!item?.id) return;
+      const singleItemPayload = {
+        id: item.id,
+        sku: item.sku || '-',
+        ean13: buildItemEan13(item.sku, item.unitsPerBox),
+        code: item.code || '-',
+        description: item.description || '-'
+      };
+      setSelectedItemsForPrint(prev => ({ ...prev, [item.id]: singleItemPayload }));
+      handlePrintConfirm([singleItemPayload]);
+    },
+    [handlePrintConfirm]
+  );
+
+  const handleDownloadSelectedPdf = async () => {
+    if (printing) return;
+    const printWindow = window.open('', '_blank');
+    if (!printWindow) {
+      setError(new Error('No se pudo abrir la ventana de impresión. Verificá si el navegador bloqueó la ventana emergente.'));
+      return;
+    }
+
+    printWindow.document.open();
+    printWindow.document.write(`
+      <!doctype html>
+      <html lang="es">
+        <head>
+          <meta charset="utf-8" />
+          <title>Preparando PDF…</title>
+        </head>
+        <body>
+          <h1>Preparando PDF…</h1>
+        </body>
+      </html>
+    `);
+    printWindow.document.close();
+
+    setPrinting(true);
+    setError(null);
+    try {
+      const collectedItems = [...selectedItemsList];
+      if (collectedItems.length === 0) {
+        throw new Error('Seleccioná al menos un artículo para generar el PDF.');
+      }
+
+      const printedAt = new Date().toLocaleString('es-AR', {
+        dateStyle: 'short',
+        timeStyle: 'short'
+      });
+
+      const tableRows = collectedItems
+        .map(item => {
+          return `
+            <tr>
+              <td>${escapeHtml(item.sku || '-')}</td>
+              <td>${escapeHtml(item.ean13 || '-')}</td>
+              <td>${escapeHtml(item.code || '-')}</td>
+              <td>${escapeHtml(item.description || '-')}</td>
+            </tr>
+          `;
+        })
+        .join('');
+
+      printWindow.document.open();
+      printWindow.document.write(`
+        <!doctype html>
+        <html lang="es">
+          <head>
+            <meta charset="utf-8" />
+            <title>Listado de artículos seleccionados</title>
+            <style>
+              body { font-family: Arial, sans-serif; margin: 24px; color: #0f172a; }
+              h1 { margin: 0 0 8px; font-size: 22px; }
+              p { margin: 0 0 6px; color: #334155; }
+              .meta { margin-bottom: 14px; }
+              table { width: 100%; border-collapse: collapse; margin-top: 12px; font-size: 12px; }
+              th, td { border: 1px solid #cbd5e1; padding: 8px; text-align: left; vertical-align: top; }
+              th { background: #f8fafc; }
+              @media print {
+                @page { size: A4 portrait; margin: 12mm; }
+                body { margin: 0; }
+              }
+            </style>
+          </head>
+          <body>
+            <h1>Listado de artículos seleccionados</h1>
+            <div class="meta">
+              <p><strong>Total:</strong> ${collectedItems.length}</p>
+              <p><strong>Fecha de impresión:</strong> ${escapeHtml(printedAt)}</p>
+            </div>
+            <table>
+              <thead>
+                <tr>
+                  <th>SKU</th>
+                  <th>EAN13</th>
+                  <th>Artículo</th>
+                  <th>Descripción</th>
+                </tr>
+              </thead>
+              <tbody>
+                ${tableRows}
+              </tbody>
+            </table>
+          </body>
+        </html>
+      `);
+      printWindow.document.close();
+      printWindow.focus();
+      printWindow.print();
+    } catch (err) {
+      setError(err);
+    } finally {
+      setPrinting(false);
+    }
+  };
+
   if (!canRead) {
     return <ErrorMessage error={new Error('No tenés permisos para ver esta sección.')} />;
   }
@@ -421,15 +679,26 @@ export default function ItemsDownloadPage() {
       <div className="section-card">
         <div className="flex-between">
           <h2>Buscar artículos para descarga</h2>
-          <button
-            type="button"
-            className="secondary-button"
-            onClick={handlePrintFilteredItems}
-            disabled={printing || selectedItemsList.length === 0}
-            title={selectedItemsList.length === 0 ? 'Seleccioná artículos para habilitar la descarga.' : undefined}
-          >
-            {printing ? 'Preparando impresión…' : 'Descargar filtrados'}
-          </button>
+          <div className="inline-actions">
+            <button
+              type="button"
+              className="secondary-button"
+              onClick={handleDownloadSelectedPdf}
+              disabled={printing || selectedItemsList.length === 0}
+              title={selectedItemsList.length === 0 ? 'Seleccioná artículos para habilitar la descarga.' : undefined}
+            >
+              {printing ? 'Preparando impresión…' : 'Descargar PDF'}
+            </button>
+            <button
+              type="button"
+              className="secondary-button"
+              onClick={() => handlePrintConfirm(selectedItemsList)}
+              disabled={printing || selectedItemsList.length === 0}
+              title={selectedItemsList.length === 0 ? 'Seleccioná artículos para habilitar la descarga.' : undefined}
+            >
+              {printing ? 'Preparando impresión…' : 'Imprimir etiquetas A4'}
+            </button>
+          </div>
         </div>
         <form className="form-grid" style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))' }}>
           <div className="input-group">
@@ -577,6 +846,7 @@ export default function ItemsDownloadPage() {
                   <th>EAN13</th>
                   <th>Artículo</th>
                   <th>Descripción</th>
+                  <th>Etiqueta</th>
                 </tr>
               </thead>
               <tbody>
@@ -596,12 +866,17 @@ export default function ItemsDownloadPage() {
                       <td>{buildItemEan13(item.sku, item.unitsPerBox) || '-'}</td>
                       <td>{item.code}</td>
                       <td>{item.description}</td>
+                      <td>
+                        <button type="button" className="secondary-button" onClick={() => handlePrintSingleLabel(item)}>
+                          Imprimir etiqueta
+                        </button>
+                      </td>
                     </tr>
                   );
                 })}
                 {items.length === 0 && (
                   <tr>
-                    <td colSpan={5} style={{ textAlign: 'center', padding: '1.5rem 0' }}>
+                    <td colSpan={6} style={{ textAlign: 'center', padding: '1.5rem 0' }}>
                       No se encontraron artículos para los filtros seleccionados.
                     </td>
                   </tr>


### PR DESCRIPTION
### Motivation
- Provide printable EAN‑13 labels for items in A4 label layout and allow single‑label printing from the items list. 
- Keep the existing PDF table download behavior while introducing a dedicated A4 label printing flow and confirmation.

### Description
- Implemented EAN‑13 barcode support including `sanitizeEan13`, `buildEan13Binary`, and `buildEan13SvgMarkup` and parity/pattern constants for EAN‑13 encoding. 
- Added new print flows and handlers: `handlePrintLabelsA4` to render an A4 label grid with SVG barcodes, `handlePrintConfirm` to prompt before printing, `handlePrintSingleLabel` to print one item's label, and `handleDownloadSelectedPdf` to preserve the tabular PDF download. 
- Updated UI to include two actions (`Descargar PDF` and `Imprimir etiquetas A4`) and a per‑row `Imprimir etiqueta` button, adjusted table columns, and added styles for the labels grid, barcode sizing, and print @media rules. 
- Replaced the previous table‑only printable output with a label card grid for A4 printing while keeping the original PDF table generation logic in a dedicated function.

### Testing
- Ran project linting with `npm run lint` and the frontend automated test suite with `npm test`, and both completed without failures. 
- Manually exercised the new flows in a development build to confirm label rendering, single label printing, and the download PDF path worked end‑to‑end.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8e04ccce0832aa5ac37fb5944d305)