### PR TITLE
Quitar columnas SKU y EAN13 en mantenimiento de artículos

### DIFF
--- a/frontend/src/pages/items/ItemsPage.jsx
+++ b/frontend/src/pages/items/ItemsPage.jsx
@@ -7,7 +7,6 @@ import { ensureQuantity, formatQuantity } from '../../utils/quantity.js';
 import StockStatusBadge from '../../components/StockStatusBadge.jsx';
 import { aggregatePendingByItem, computeTotalStockFromMap, deriveStockStatus } from '../../utils/stockStatus.js';
 import { API_ROOT_URL } from '../../utils/apiConfig.js';
-import { buildItemEan13 } from '../../utils/ean13.js';
 
 const ATTRIBUTE_FIELDS = [
   {
@@ -1261,8 +1260,6 @@ export default function ItemsPage() {
             <table>
               <thead>
                 <tr>
-                  <th>SKU</th>
-                  <th>EAN13</th>
                   <th>Código</th>
                   <th>Descripción</th>
                   <th>Grupo</th>
@@ -1289,32 +1286,30 @@ export default function ItemsPage() {
                         : null;
                   return (
                     <tr key={item.id}>
-                    <td>{item.sku || "-"}</td>
-                    <td>{buildItemEan13(item.sku, item.unitsPerBox) || '-'}</td>
-                    <td>{item.code}</td>
-                    <td>{item.description}</td>
-                    <td>{item.group?.name || 'Sin grupo'}</td>
-                    <td>
-                      {precioBase === null
-                        ? '-'
-                        : Number(precioBase).toLocaleString('es-AR', {
-                            minimumFractionDigits: 2,
-                            maximumFractionDigits: 2
-                          })}
-                    </td>
-                    <td>
-                      <div className="chip-list">
-                        {Object.entries(item.attributes || {}).map(([key, value]) => (
-                          <span key={key} className="badge">
-                            {key}: {value}
-                          </span>
-                        ))}
-                        {Object.keys(item.attributes || {}).length === 0 && <span>-</span>}
-                      </div>
-                    </td>
-                    <td>{item.unitsPerBox === null || item.unitsPerBox === undefined ? '-' : item.unitsPerBox}</td>
-                    <td>{Array.isArray(item.images) ? item.images.length : 0}</td>
-                  <td>
+                      <td>{item.code}</td>
+                      <td>{item.description}</td>
+                      <td>{item.group?.name || 'Sin grupo'}</td>
+                      <td>
+                        {precioBase === null
+                          ? '-'
+                          : Number(precioBase).toLocaleString('es-AR', {
+                              minimumFractionDigits: 2,
+                              maximumFractionDigits: 2
+                            })}
+                      </td>
+                      <td>
+                        <div className="chip-list">
+                          {Object.entries(item.attributes || {}).map(([key, value]) => (
+                            <span key={key} className="badge">
+                              {key}: {value}
+                            </span>
+                          ))}
+                          {Object.keys(item.attributes || {}).length === 0 && <span>-</span>}
+                        </div>
+                      </td>
+                      <td>{item.unitsPerBox === null || item.unitsPerBox === undefined ? '-' : item.unitsPerBox}</td>
+                      <td>{Array.isArray(item.images) ? item.images.length : 0}</td>
+                      <td>
                       <div className="chip-list">
                         {(() => {
                           const stockEntries = Object.entries(
@@ -1340,56 +1335,56 @@ export default function ItemsPage() {
                           });
                         })()}
                       </div>
-                    </td>
-                    <td>{formatQuantity(totalQuantity)}</td>
-                    <td>
-                      {item.needsRecount ? (
-                        <span className="badge" style={{ backgroundColor: '#f97316', color: '#fff' }}>
-                          Reconteo pendiente
-                        </span>
-                      ) : (
-                        <span style={{ color: '#64748b', fontSize: '0.85rem' }}>Al día</span>
-                      )}
-                    </td>
-                    <td>
-                      {stockStatus ? (
-                        <div className="stock-status-cell">
-                          <StockStatusBadge status={stockStatus} />
-                          {stockStatus.pendingCount > 0 && (
-                            <span className="stock-status-note">
-                              {stockStatus.pendingCount === 1
-                                ? '1 solicitud pendiente'
-                                : `${stockStatus.pendingCount} solicitudes pendientes`}
-                            </span>
-                          )}
-                        </div>
-                      ) : (
-                        '-'
-                      )}
-                    </td>
-                    {canWrite && (
-                      <td>
-                        <div className="inline-actions">
-                          <button type="button" className="secondary-button" onClick={() => handleEdit(item)}>
-                            Editar
-                          </button>
-                          <button
-                            type="button"
-                            className="danger-button"
-                            onClick={() => handleDelete(item)}
-                            disabled={deletingId === item.id}
-                          >
-                            {deletingId === item.id ? 'Eliminando…' : 'Eliminar'}
-                          </button>
-                        </div>
                       </td>
-                    )}
-                  </tr>
+                      <td>{formatQuantity(totalQuantity)}</td>
+                      <td>
+                        {item.needsRecount ? (
+                          <span className="badge" style={{ backgroundColor: '#f97316', color: '#fff' }}>
+                            Reconteo pendiente
+                          </span>
+                        ) : (
+                          <span style={{ color: '#64748b', fontSize: '0.85rem' }}>Al día</span>
+                        )}
+                      </td>
+                      <td>
+                        {stockStatus ? (
+                          <div className="stock-status-cell">
+                            <StockStatusBadge status={stockStatus} />
+                            {stockStatus.pendingCount > 0 && (
+                              <span className="stock-status-note">
+                                {stockStatus.pendingCount === 1
+                                  ? '1 solicitud pendiente'
+                                  : `${stockStatus.pendingCount} solicitudes pendientes`}
+                              </span>
+                            )}
+                          </div>
+                        ) : (
+                          '-'
+                        )}
+                      </td>
+                      {canWrite && (
+                        <td>
+                          <div className="inline-actions">
+                            <button type="button" className="secondary-button" onClick={() => handleEdit(item)}>
+                              Editar
+                            </button>
+                            <button
+                              type="button"
+                              className="danger-button"
+                              onClick={() => handleDelete(item)}
+                              disabled={deletingId === item.id}
+                            >
+                              {deletingId === item.id ? 'Eliminando…' : 'Eliminar'}
+                            </button>
+                          </div>
+                        </td>
+                      )}
+                    </tr>
                 );
               })}
               {items.length === 0 && (
                 <tr>
-                  <td colSpan={canWrite ? 14 : 13} style={{ textAlign: 'center', padding: '1.5rem 0' }}>
+                  <td colSpan={canWrite ? 12 : 11} style={{ textAlign: 'center', padding: '1.5rem 0' }}>
                     No se encontraron artículos para los filtros seleccionados.
                   </td>
                 </tr>


### PR DESCRIPTION
### Motivation
- Simplificar la vista de mantenimiento de artículos eliminando las columnas `SKU` y `EAN13` de la grilla principal.

### Description
- Eliminé las celdas de encabezado y las celdas por fila para `SKU` y `EAN13` en `frontend/src/pages/items/ItemsPage.jsx`.
- Quité la importación no utilizada `buildItemEan13` de `frontend/src/pages/items/ItemsPage.jsx` tras eliminar la columna EAN13.
- Ajusté el `colSpan` del renglón de estado vacío en la tabla (`colSpan` cambiado a `12` cuando hay permisos de escritura o `11` si no los hay) para que coincida con la nueva cantidad de columnas.
- Reorganicé el JSX de celdas por fila para mantener la alineación y las acciones sin cambios funcionales adicionales.

### Testing
- Ejecutado `npm run build` en la carpeta `frontend/` y la compilación completó correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e90b8010dc832aad33bacdc423ddee)