### PR TITLE
Add structured `details` to audit logs and render them in the UI

### DIFF
--- a/backend/src/models/AuditLog.js
+++ b/backend/src/models/AuditLog.js
@@ -5,6 +5,7 @@ const auditLogSchema = new Schema(
     action: { type: String, required: true, trim: true },
     request: { type: String, required: true, trim: true },
     user: { type: String, required: true, trim: true },
+    details: { type: Schema.Types.Mixed, default: {} },
     timestamp: { type: Date, default: Date.now }
   },
   {

--- a/backend/src/routes/items.js
+++ b/backend/src/routes/items.js
@@ -335,6 +335,45 @@ function toPlainStock(stock) {
   return plain;
 }
 
+
+function buildItemAuditSnapshot(doc) {
+  if (!doc) {
+    return null;
+  }
+  const group = doc.group;
+  const groupId = group && typeof group === 'object' && group.id ? group.id : group ? String(group) : null;
+  return {
+    id: doc.id || (doc._id ? String(doc._id) : null),
+    code: doc.code,
+    sku: doc.sku || null,
+    description: doc.description,
+    groupId,
+    groupName: group && typeof group === 'object' && group.name ? group.name : null,
+    attributes: toPlainAttributes(doc.attributes),
+    stock: toPlainStock(doc.stock),
+    unitsPerBox: doc.unitsPerBox === undefined || doc.unitsPerBox === null ? null : Number(doc.unitsPerBox),
+    precio: doc.pDecimal === undefined || doc.pDecimal === null ? null : Number(doc.pDecimal),
+    needsRecount: Boolean(doc.needsRecount),
+    imageCount: Array.isArray(doc.images) ? doc.images.length : 0
+  };
+}
+
+function buildItemAuditChanges(before, after) {
+  const changes = {};
+  if (!before || !after) {
+    return changes;
+  }
+  Object.keys(after).forEach(key => {
+    if (JSON.stringify(before[key]) !== JSON.stringify(after[key])) {
+      changes[key] = {
+        before: before[key] === undefined ? null : before[key],
+        after: after[key] === undefined ? null : after[key]
+      };
+    }
+  });
+  return changes;
+}
+
 function buildStock(input = {}) {
   const stock = {};
   if (!input || typeof input !== 'object') {
@@ -517,7 +556,10 @@ router.post(
     await recordAuditEvent({
       action: 'Artículo',
       request: 'Alta de artículo',
-      user: req.user?.username || 'Desconocido'
+      user: req.user?.username || 'Desconocido',
+      details: {
+        item: buildItemAuditSnapshot(populated)
+      }
     });
     res.status(201).json(serializeItem(populated));
   })
@@ -535,6 +577,7 @@ router.put(
     if (!item) {
       throw new HttpError(404, 'Artículo no encontrado');
     }
+    const beforeAuditSnapshot = buildItemAuditSnapshot(item);
     const payload = parseItemPayload(req);
     const {
       description,
@@ -705,10 +748,15 @@ router.put(
       throw error;
     }
     const populated = await item.populate('group');
+    const afterAuditSnapshot = buildItemAuditSnapshot(populated);
     await recordAuditEvent({
       action: 'Artículo',
       request: 'Actualización de artículo',
-      user: req.user?.username || 'Desconocido'
+      user: req.user?.username || 'Desconocido',
+      details: {
+        item: afterAuditSnapshot,
+        changes: buildItemAuditChanges(beforeAuditSnapshot, afterAuditSnapshot)
+      }
     });
     res.json(serializeItem(populated));
   })
@@ -727,6 +775,7 @@ router.delete(
       throw new HttpError(404, 'Artículo no encontrado');
     }
 
+    const auditSnapshot = buildItemAuditSnapshot(item);
     const imagesToRemove = Array.isArray(item.images)
       ? item.images.map(sanitizeImagePath).filter(Boolean)
       : [];
@@ -740,7 +789,10 @@ router.delete(
     await recordAuditEvent({
       action: 'Artículo',
       request: 'Eliminación de artículo',
-      user: req.user?.username || 'Desconocido'
+      user: req.user?.username || 'Desconocido',
+      details: {
+        item: auditSnapshot
+      }
     });
 
     res.status(204).send();

--- a/backend/src/routes/logs.js
+++ b/backend/src/routes/logs.js
@@ -97,6 +97,7 @@ router.get(
         action: log.action,
         request: log.request,
         user: log.user,
+        details: log.details && typeof log.details === 'object' ? log.details : {},
         timestamp: log.timestamp
       }))
     );

--- a/backend/src/routes/stock.js
+++ b/backend/src/routes/stock.js
@@ -179,6 +179,14 @@ function serializeMovementRequest(doc) {
   };
 }
 
+
+function buildMovementAuditDetails(doc, extra = {}) {
+  return {
+    movementRequest: serializeMovementRequest(doc),
+    ...extra
+  };
+}
+
 function requestMetadata(req) {
   return {
     ip: req.ip,
@@ -286,7 +294,13 @@ router.delete(
     }
 
     const { id } = req.params;
-    const request = await MovementRequest.findById(id);
+    const request = await MovementRequest.findById(id).populate([
+      'item',
+      { path: 'requestedBy', populate: 'role' },
+      { path: 'approvedBy', populate: 'role' },
+      'fromLocation',
+      'toLocation'
+    ]);
     if (!request) {
       throw new HttpError(404, 'Solicitud no encontrada');
     }
@@ -299,7 +313,8 @@ router.delete(
     await recordAuditEvent({
       action: 'Solicitud de movimiento',
       request: 'Eliminación de solicitud',
-      user: req.user?.username || 'Desconocido'
+      user: req.user?.username || 'Desconocido',
+      details: buildMovementAuditDetails(request)
     });
 
     res.status(204).send();
@@ -330,11 +345,6 @@ router.post(
 
     await movementRequest.save();
     await addMovementLog(movementRequest.id, 'requested', req.user.id, requestMetadata(req));
-    await recordAuditEvent({
-      action: 'Solicitud de movimiento',
-      request: 'Nueva solicitud',
-      user: req.user?.username || 'Desconocido'
-    });
 
     const populated = await movementRequest.populate([
       'item',
@@ -343,6 +353,12 @@ router.post(
       'fromLocation',
       'toLocation'
     ]);
+    await recordAuditEvent({
+      action: 'Solicitud de movimiento',
+      request: 'Nueva solicitud',
+      user: req.user?.username || 'Desconocido',
+      details: buildMovementAuditDetails(populated)
+    });
     res.status(201).json(serializeMovementRequest(populated));
   })
 );
@@ -364,11 +380,6 @@ router.post(
     request.approvedAt = new Date();
     await addMovementLog(request.id, 'approved', req.user.id, requestMetadata(req));
     await executeMovement(request, req.user.id, requestMetadata(req));
-    await recordAuditEvent({
-      action: 'Solicitud de movimiento',
-      request: 'Aprobación de solicitud',
-      user: req.user?.username || 'Desconocido'
-    });
     const populated = await request.populate([
       'item',
       { path: 'requestedBy', populate: 'role' },
@@ -376,6 +387,12 @@ router.post(
       'fromLocation',
       'toLocation'
     ]);
+    await recordAuditEvent({
+      action: 'Solicitud de movimiento',
+      request: 'Aprobación de solicitud',
+      user: req.user?.username || 'Desconocido',
+      details: buildMovementAuditDetails(populated)
+    });
     res.json(serializeMovementRequest(populated));
   })
 );
@@ -399,11 +416,6 @@ router.post(
     request.approvedAt = new Date();
     await request.save();
     await addMovementLog(request.id, 'rejected', req.user.id, requestMetadata(req));
-    await recordAuditEvent({
-      action: 'Solicitud de movimiento',
-      request: 'Rechazo de solicitud',
-      user: req.user?.username || 'Desconocido'
-    });
     const populated = await request.populate([
       'item',
       { path: 'requestedBy', populate: 'role' },
@@ -411,6 +423,12 @@ router.post(
       'fromLocation',
       'toLocation'
     ]);
+    await recordAuditEvent({
+      action: 'Solicitud de movimiento',
+      request: 'Rechazo de solicitud',
+      user: req.user?.username || 'Desconocido',
+      details: buildMovementAuditDetails(populated, { rejectionReason: request.rejectedReason })
+    });
     res.json(serializeMovementRequest(populated));
   })
 );
@@ -563,11 +581,6 @@ router.post(
     request.rejectedReason = null;
     await request.save();
     await addMovementLog(request.id, 'resubmitted', req.user.id, requestMetadata(req));
-    await recordAuditEvent({
-      action: 'Solicitud de movimiento',
-      request: 'Reenvío de solicitud',
-      user: req.user?.username || 'Desconocido'
-    });
     const populated = await request.populate([
       'item',
       { path: 'requestedBy', populate: 'role' },
@@ -575,6 +588,12 @@ router.post(
       'fromLocation',
       'toLocation'
     ]);
+    await recordAuditEvent({
+      action: 'Solicitud de movimiento',
+      request: 'Reenvío de solicitud',
+      user: req.user?.username || 'Desconocido',
+      details: buildMovementAuditDetails(populated)
+    });
     res.json(serializeMovementRequest(populated));
   })
 );

--- a/backend/src/services/auditService.js
+++ b/backend/src/services/auditService.js
@@ -10,7 +10,14 @@ function normalizeText(value, { fallback = '' } = {}) {
   return String(value).trim();
 }
 
-async function recordAuditEvent({ action, request, user }) {
+function normalizeDetails(value) {
+  if (value === undefined || value === null || typeof value !== 'object') {
+    return {};
+  }
+  return value;
+}
+
+async function recordAuditEvent({ action, request, user, details }) {
   const actionValue = normalizeText(action);
   const requestValue = normalizeText(request);
   const userValue = normalizeText(user, { fallback: 'Desconocido' });
@@ -22,7 +29,8 @@ async function recordAuditEvent({ action, request, user }) {
   await AuditLog.create({
     action: actionValue,
     request: requestValue,
-    user: userValue
+    user: userValue,
+    details: normalizeDetails(details)
   });
 }
 

--- a/frontend/src/pages/audit/AuditLogsPage.jsx
+++ b/frontend/src/pages/audit/AuditLogsPage.jsx
@@ -11,6 +11,141 @@ const ACTION_LABELS = {
   Autenticación: 'Autenticación'
 };
 
+const DETAIL_LABELS = {
+  item: 'Artículo',
+  movementRequest: 'Solicitud de movimiento',
+  changes: 'Cambios',
+  id: 'ID',
+  code: 'Código',
+  sku: 'SKU',
+  description: 'Descripción',
+  groupId: 'ID grupo',
+  groupName: 'Grupo',
+  attributes: 'Atributos',
+  stock: 'Stock',
+  unitsPerBox: 'Unidades por caja',
+  precio: 'Precio',
+  needsRecount: 'Requiere recuento',
+  imageCount: 'Cantidad de imágenes',
+  itemId: 'ID artículo',
+  type: 'Tipo',
+  fromLocationId: 'ID origen',
+  fromLocation: 'Origen',
+  toLocationId: 'ID destino',
+  toLocation: 'Destino',
+  quantity: 'Cantidad',
+  reason: 'Motivo',
+  requestedBy: 'Solicitado por',
+  requestedAt: 'Fecha de solicitud',
+  status: 'Estado',
+  approvedBy: 'Aprobado por',
+  approvedAt: 'Fecha de aprobación',
+  executedAt: 'Fecha de ejecución',
+  rejectedReason: 'Motivo de rechazo',
+  rejectionReason: 'Motivo de rechazo',
+  before: 'Antes',
+  after: 'Después',
+  boxes: 'Cajas',
+  units: 'Unidades',
+  name: 'Nombre',
+  email: 'Email',
+  role: 'Rol'
+};
+
+const MOVEMENT_TYPE_LABELS = {
+  ingress: 'Ingreso',
+  egress: 'Egreso',
+  transfer: 'Transferencia'
+};
+
+const STATUS_LABELS = {
+  pending: 'Pendiente',
+  approved: 'Aprobada',
+  rejected: 'Rechazada',
+  executed: 'Ejecutada'
+};
+
+const labelFor = key => DETAIL_LABELS[key] || key;
+
+const isPlainObject = value => value && typeof value === 'object' && !Array.isArray(value);
+
+const hasDetails = details => isPlainObject(details) && Object.keys(details).length > 0;
+
+const isQuantity = value =>
+  isPlainObject(value) &&
+  Object.prototype.hasOwnProperty.call(value, 'boxes') &&
+  Object.prototype.hasOwnProperty.call(value, 'units') &&
+  Object.keys(value).every(key => ['boxes', 'units'].includes(key));
+
+const formatPrimitive = (key, value) => {
+  if (value === null || value === undefined || value === '') {
+    return '-';
+  }
+  if (typeof value === 'boolean') {
+    return value ? 'Sí' : 'No';
+  }
+  if (key === 'type' && MOVEMENT_TYPE_LABELS[value]) {
+    return MOVEMENT_TYPE_LABELS[value];
+  }
+  if (key === 'status' && STATUS_LABELS[value]) {
+    return STATUS_LABELS[value];
+  }
+  if (typeof value === 'string' && /At$/.test(key)) {
+    const date = new Date(value);
+    if (!Number.isNaN(date.getTime())) {
+      return date.toLocaleString('es-AR');
+    }
+  }
+  return String(value);
+};
+
+function renderAuditDetailValue(value, keyPrefix) {
+  if (isQuantity(value)) {
+    return `${Number(value.boxes) || 0} caja(s), ${Number(value.units) || 0} unidad(es)`;
+  }
+  if (Array.isArray(value)) {
+    if (value.length === 0) {
+      return '-';
+    }
+    return (
+      <ul style={{ margin: '0.25rem 0 0', paddingLeft: '1.1rem' }}>
+        {value.map((entry, index) => (
+          <li key={`${keyPrefix}-${index}`}>{renderAuditDetailValue(entry, `${keyPrefix}-${index}`)}</li>
+        ))}
+      </ul>
+    );
+  }
+  if (isPlainObject(value)) {
+    const entries = Object.entries(value).filter(([, entryValue]) => entryValue !== undefined);
+    if (entries.length === 0) {
+      return '-';
+    }
+    return (
+      <dl style={{ margin: '0.25rem 0 0', display: 'grid', gap: '0.35rem' }}>
+        {entries.map(([entryKey, entryValue]) => (
+          <div key={`${keyPrefix}-${entryKey}`} style={{ display: 'grid', gap: '0.1rem' }}>
+            <dt style={{ color: '#475569', fontWeight: 700 }}>{labelFor(entryKey)}</dt>
+            <dd style={{ margin: 0 }}>{renderAuditDetailValue(entryValue, `${keyPrefix}-${entryKey}`)}</dd>
+          </div>
+        ))}
+      </dl>
+    );
+  }
+  return formatPrimitive(keyPrefix.split('-').pop(), value);
+}
+
+function AuditDetails({ details }) {
+  if (!hasDetails(details)) {
+    return <span style={{ color: '#94a3b8' }}>Sin datos adicionales</span>;
+  }
+  return (
+    <details>
+      <summary style={{ cursor: 'pointer', color: '#2563eb', fontWeight: 700 }}>Ver datos registrados</summary>
+      <div style={{ marginTop: '0.5rem', maxWidth: '42rem' }}>{renderAuditDetailValue(details, 'details')}</div>
+    </details>
+  );
+}
+
 const getDefaultDateRange = () => {
   const to = new Date();
   const from = new Date();
@@ -192,6 +327,7 @@ export default function AuditLogsPage() {
                   <th>Fecha</th>
                   <th>Acción</th>
                   <th>Detalle</th>
+                  <th>Datos registrados</th>
                   <th>Usuario</th>
                 </tr>
               </thead>
@@ -201,12 +337,13 @@ export default function AuditLogsPage() {
                     <td>{new Date(log.timestamp).toLocaleString('es-AR')}</td>
                     <td>{getActionLabel(log.action)}</td>
                     <td>{log.request || '-'}</td>
+                    <td><AuditDetails details={log.details} /></td>
                     <td>{log.user || '-'}</td>
                   </tr>
                 ))}
                 {logs.length === 0 && (
                   <tr>
-                    <td colSpan={4} style={{ textAlign: 'center', padding: '1.5rem 0' }}>
+                    <td colSpan={5} style={{ textAlign: 'center', padding: '1.5rem 0' }}>
                       No se encontraron registros.
                     </td>
                   </tr>


### PR DESCRIPTION
### Motivation
- Capture richer, structured context for audit events (item snapshots/changes and movement requests) so audits are more informative and machine-readable.
- Surface those structured details in the audit UI to allow users to inspect what changed or was recorded for each event.

### Description
- Add a `details` field to the `AuditLog` schema (`backend/src/models/AuditLog.js`) and normalize it in `recordAuditEvent` (`backend/src/services/auditService.js`).
- Record item snapshots and change sets by adding `buildItemAuditSnapshot` and `buildItemAuditChanges` helpers and including `details` on item create/update/delete audit calls (`backend/src/routes/items.js`).
- Enrich stock movement audit entries by populating `MovementRequest` references and adding `buildMovementAuditDetails`, then include structured `details` for create/approve/reject/resubmit/delete actions (`backend/src/routes/stock.js`).
- Return `details` from the audit listing endpoint with a safe default (`backend/src/routes/logs.js`).
- Add a UI for viewing structured audit details in `AuditLogsPage` (`frontend/src/pages/audit/AuditLogsPage.jsx`) including label maps, formatters, a collapsible `AuditDetails` component, and a new table column to display recorded data.

### Testing
- Ran backend unit tests and linting (`npm test` / `npm run lint`) with no failures reported. 
- Built frontend (`npm run build`) and verified the audit logs page renders without runtime errors in automated CI build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdd5acca28832a9f6af3b5bbc7342f)