### PR TITLE
Add structured audit details and enhanced audit UI/filters for items and movements

### DIFF
--- a/backend/src/models/AuditLog.js
+++ b/backend/src/models/AuditLog.js
@@ -5,6 +5,7 @@ const auditLogSchema = new Schema(
     action: { type: String, required: true, trim: true },
     request: { type: String, required: true, trim: true },
     user: { type: String, required: true, trim: true },
+    details: { type: Schema.Types.Mixed, default: {} },
     timestamp: { type: Date, default: Date.now }
   },
   {

--- a/backend/src/routes/items.js
+++ b/backend/src/routes/items.js
@@ -8,6 +8,7 @@ const { HttpError } = require('../utils/errors');
 const { requirePermission } = require('../middlewares/auth');
 const Item = require('../models/Item');
 const Group = require('../models/Group');
+const Location = require('../models/Location');
 const { normalizeQuantityInput } = require('../services/stockService');
 const { recordAuditEvent } = require('../services/auditService');
 const { collectGroupAndDescendantIds, buildGroupFilterValues } = require('../services/groupService');
@@ -335,6 +336,86 @@ function toPlainStock(stock) {
   return plain;
 }
 
+
+
+function formatAuditQuantity(quantity) {
+  const boxes = Number(quantity?.boxes) || 0;
+  const units = Number(quantity?.units) || 0;
+  return `${boxes} caja(s), ${units} unidad(es)`;
+}
+
+async function buildFriendlyAuditStock(stock = {}) {
+  const plainStock = toPlainStock(stock);
+  const entries = Object.entries(plainStock);
+  if (entries.length === 0) {
+    return [];
+  }
+
+  const locationIds = entries.map(([locationId]) => locationId).filter(Types.ObjectId.isValid);
+  const locations = locationIds.length > 0
+    ? await Location.find({ _id: { $in: locationIds } }).select('name description').lean()
+    : [];
+  const locationNames = new Map(locations.map(location => [String(location._id), location.name]));
+
+  return entries.map(([locationId, quantity], index) => ({
+    ubicacion: locationNames.get(locationId) || `Ubicación ${index + 1}`,
+    cantidad: formatAuditQuantity(quantity),
+    boxes: Number(quantity?.boxes) || 0,
+    units: Number(quantity?.units) || 0
+  }));
+}
+
+function formatAuditStock(stock = []) {
+  if (!Array.isArray(stock) || stock.length === 0) {
+    return 'sin stock registrado';
+  }
+  return stock
+    .map(entry => `${entry.ubicacion}: ${entry.cantidad}`)
+    .join('; ');
+}
+
+function buildItemAuditSummary(operation, snapshot) {
+  if (!snapshot) {
+    return operation;
+  }
+  const stockSummary = formatAuditStock(snapshot.stock);
+  return `${operation}: ${snapshot.code} - ${snapshot.description} | Stock: ${stockSummary}`;
+}
+
+async function buildItemAuditSnapshot(doc) {
+  if (!doc) {
+    return null;
+  }
+  const group = doc.group;
+  return {
+    code: doc.code,
+    description: doc.description,
+    groupName: group && typeof group === 'object' && group.name ? group.name : null,
+    attributes: toPlainAttributes(doc.attributes),
+    stock: await buildFriendlyAuditStock(doc.stock),
+    unitsPerBox: doc.unitsPerBox === undefined || doc.unitsPerBox === null ? null : Number(doc.unitsPerBox),
+    precio: doc.pDecimal === undefined || doc.pDecimal === null ? null : Number(doc.pDecimal),
+    needsRecount: Boolean(doc.needsRecount),
+    imageCount: Array.isArray(doc.images) ? doc.images.length : 0
+  };
+}
+
+function buildItemAuditChanges(before, after) {
+  const changes = {};
+  if (!before || !after) {
+    return changes;
+  }
+  Object.keys(after).forEach(key => {
+    if (JSON.stringify(before[key]) !== JSON.stringify(after[key])) {
+      changes[key] = {
+        before: before[key] === undefined ? null : before[key],
+        after: after[key] === undefined ? null : after[key]
+      };
+    }
+  });
+  return changes;
+}
+
 function buildStock(input = {}) {
   const stock = {};
   if (!input || typeof input !== 'object') {
@@ -514,10 +595,15 @@ router.post(
       throw error;
     }
     const populated = await item.populate('group');
+    const auditSnapshot = await buildItemAuditSnapshot(populated);
     await recordAuditEvent({
       action: 'Artículo',
-      request: 'Alta de artículo',
-      user: req.user?.username || 'Desconocido'
+      request: buildItemAuditSummary('Alta de artículo', auditSnapshot),
+      user: req.user?.username || 'Desconocido',
+      details: {
+        summary: buildItemAuditSummary('Alta de artículo', auditSnapshot),
+        item: auditSnapshot
+      }
     });
     res.status(201).json(serializeItem(populated));
   })
@@ -535,6 +621,7 @@ router.put(
     if (!item) {
       throw new HttpError(404, 'Artículo no encontrado');
     }
+    const beforeAuditSnapshot = await buildItemAuditSnapshot(item);
     const payload = parseItemPayload(req);
     const {
       description,
@@ -705,10 +792,16 @@ router.put(
       throw error;
     }
     const populated = await item.populate('group');
+    const afterAuditSnapshot = await buildItemAuditSnapshot(populated);
     await recordAuditEvent({
       action: 'Artículo',
-      request: 'Actualización de artículo',
-      user: req.user?.username || 'Desconocido'
+      request: buildItemAuditSummary('Actualización de artículo', afterAuditSnapshot),
+      user: req.user?.username || 'Desconocido',
+      details: {
+        summary: buildItemAuditSummary('Actualización de artículo', afterAuditSnapshot),
+        item: afterAuditSnapshot,
+        changes: buildItemAuditChanges(beforeAuditSnapshot, afterAuditSnapshot)
+      }
     });
     res.json(serializeItem(populated));
   })
@@ -727,6 +820,7 @@ router.delete(
       throw new HttpError(404, 'Artículo no encontrado');
     }
 
+    const auditSnapshot = await buildItemAuditSnapshot(item);
     const imagesToRemove = Array.isArray(item.images)
       ? item.images.map(sanitizeImagePath).filter(Boolean)
       : [];
@@ -739,8 +833,12 @@ router.delete(
 
     await recordAuditEvent({
       action: 'Artículo',
-      request: 'Eliminación de artículo',
-      user: req.user?.username || 'Desconocido'
+      request: buildItemAuditSummary('Eliminación de artículo', auditSnapshot),
+      user: req.user?.username || 'Desconocido',
+      details: {
+        summary: buildItemAuditSummary('Eliminación de artículo', auditSnapshot),
+        item: auditSnapshot
+      }
     });
 
     res.status(204).send();

--- a/backend/src/routes/logs.js
+++ b/backend/src/routes/logs.js
@@ -62,11 +62,12 @@ router.get(
   '/audit',
   requirePermission('stock.logs.read'),
   asyncHandler(async (req, res) => {
-    const { action, request, user, limit = '100', from, to } = req.query || {};
+    const { action, request, user, item, limit = '100', from, to } = req.query || {};
     const query = {};
     const normalizedAction = typeof action === 'string' ? action.trim() : '';
     const normalizedRequest = typeof request === 'string' ? request.trim() : '';
     const normalizedUser = typeof user === 'string' ? user.trim() : '';
+    const normalizedItem = typeof item === 'string' ? item.trim() : '';
     if (normalizedAction) {
       query.action = normalizedAction;
     }
@@ -75,6 +76,20 @@ router.get(
     }
     if (normalizedUser) {
       query.user = { $regex: new RegExp(escapeRegExp(normalizedUser), 'i') };
+    }
+    if (normalizedItem) {
+      const itemMatcher = { $regex: new RegExp(escapeRegExp(normalizedItem), 'i') };
+      query.$or = [
+        { request: itemMatcher },
+        { 'details.summary': itemMatcher },
+        { 'details.item.code': itemMatcher },
+        { 'details.item.description': itemMatcher },
+        { 'details.item.id': itemMatcher },
+        { 'details.movementRequest.item.code': itemMatcher },
+        { 'details.movementRequest.item.description': itemMatcher },
+        { 'details.movementRequest.item.id': itemMatcher },
+        { 'details.movementRequest.itemId': itemMatcher }
+      ];
     }
     const range = {};
     const fromDate = parseDateBoundary(from);
@@ -97,6 +112,7 @@ router.get(
         action: log.action,
         request: log.request,
         user: log.user,
+        details: log.details && typeof log.details === 'object' ? log.details : {},
         timestamp: log.timestamp
       }))
     );

--- a/backend/src/routes/stock.js
+++ b/backend/src/routes/stock.js
@@ -179,6 +179,50 @@ function serializeMovementRequest(doc) {
   };
 }
 
+
+
+function formatAuditQuantity(quantity) {
+  const boxes = Number(quantity?.boxes) || 0;
+  const units = Number(quantity?.units) || 0;
+  return `${boxes} caja(s), ${units} unidad(es)`;
+}
+
+function movementEntityName(entity) {
+  if (!entity) {
+    return '-';
+  }
+  if (typeof entity === 'string') {
+    return entity;
+  }
+  if (entity.code || entity.description) {
+    return [entity.code, entity.description].filter(Boolean).join(' - ');
+  }
+  if (entity.name || entity.description) {
+    return [entity.name, entity.description].filter(Boolean).join(' - ');
+  }
+  if (entity.username || entity.email) {
+    return [entity.username, entity.email].filter(Boolean).join(' - ');
+  }
+  return entity.id || '-';
+}
+
+function buildMovementAuditSummary(operation, movementRequest) {
+  const serialized = movementRequest?.movementRequest ? movementRequest.movementRequest : serializeMovementRequest(movementRequest);
+  const item = movementEntityName(serialized.item || serialized.itemId);
+  const from = movementEntityName(serialized.fromLocation || serialized.fromLocationId);
+  const to = movementEntityName(serialized.toLocation || serialized.toLocationId);
+  return `${operation}: ${item} | Cantidad: ${formatAuditQuantity(serialized.quantity)} | Origen: ${from} | Destino: ${to}`;
+}
+
+function buildMovementAuditDetails(doc, operation, extra = {}) {
+  const movementRequest = serializeMovementRequest(doc);
+  return {
+    summary: buildMovementAuditSummary(operation, { movementRequest }),
+    movementRequest,
+    ...extra
+  };
+}
+
 function requestMetadata(req) {
   return {
     ip: req.ip,
@@ -286,7 +330,13 @@ router.delete(
     }
 
     const { id } = req.params;
-    const request = await MovementRequest.findById(id);
+    const request = await MovementRequest.findById(id).populate([
+      'item',
+      { path: 'requestedBy', populate: 'role' },
+      { path: 'approvedBy', populate: 'role' },
+      'fromLocation',
+      'toLocation'
+    ]);
     if (!request) {
       throw new HttpError(404, 'Solicitud no encontrada');
     }
@@ -298,8 +348,9 @@ router.delete(
 
     await recordAuditEvent({
       action: 'Solicitud de movimiento',
-      request: 'Eliminación de solicitud',
-      user: req.user?.username || 'Desconocido'
+      request: buildMovementAuditSummary('Eliminación de solicitud', request),
+      user: req.user?.username || 'Desconocido',
+      details: buildMovementAuditDetails(request, 'Eliminación de solicitud')
     });
 
     res.status(204).send();
@@ -330,11 +381,6 @@ router.post(
 
     await movementRequest.save();
     await addMovementLog(movementRequest.id, 'requested', req.user.id, requestMetadata(req));
-    await recordAuditEvent({
-      action: 'Solicitud de movimiento',
-      request: 'Nueva solicitud',
-      user: req.user?.username || 'Desconocido'
-    });
 
     const populated = await movementRequest.populate([
       'item',
@@ -343,6 +389,12 @@ router.post(
       'fromLocation',
       'toLocation'
     ]);
+    await recordAuditEvent({
+      action: 'Solicitud de movimiento',
+      request: buildMovementAuditSummary('Nueva solicitud', populated),
+      user: req.user?.username || 'Desconocido',
+      details: buildMovementAuditDetails(populated, 'Nueva solicitud')
+    });
     res.status(201).json(serializeMovementRequest(populated));
   })
 );
@@ -364,11 +416,6 @@ router.post(
     request.approvedAt = new Date();
     await addMovementLog(request.id, 'approved', req.user.id, requestMetadata(req));
     await executeMovement(request, req.user.id, requestMetadata(req));
-    await recordAuditEvent({
-      action: 'Solicitud de movimiento',
-      request: 'Aprobación de solicitud',
-      user: req.user?.username || 'Desconocido'
-    });
     const populated = await request.populate([
       'item',
       { path: 'requestedBy', populate: 'role' },
@@ -376,6 +423,12 @@ router.post(
       'fromLocation',
       'toLocation'
     ]);
+    await recordAuditEvent({
+      action: 'Solicitud de movimiento',
+      request: buildMovementAuditSummary('Aprobación de solicitud', populated),
+      user: req.user?.username || 'Desconocido',
+      details: buildMovementAuditDetails(populated, 'Aprobación de solicitud')
+    });
     res.json(serializeMovementRequest(populated));
   })
 );
@@ -399,11 +452,6 @@ router.post(
     request.approvedAt = new Date();
     await request.save();
     await addMovementLog(request.id, 'rejected', req.user.id, requestMetadata(req));
-    await recordAuditEvent({
-      action: 'Solicitud de movimiento',
-      request: 'Rechazo de solicitud',
-      user: req.user?.username || 'Desconocido'
-    });
     const populated = await request.populate([
       'item',
       { path: 'requestedBy', populate: 'role' },
@@ -411,6 +459,12 @@ router.post(
       'fromLocation',
       'toLocation'
     ]);
+    await recordAuditEvent({
+      action: 'Solicitud de movimiento',
+      request: buildMovementAuditSummary('Rechazo de solicitud', populated),
+      user: req.user?.username || 'Desconocido',
+      details: buildMovementAuditDetails(populated, 'Rechazo de solicitud', { rejectionReason: request.rejectedReason })
+    });
     res.json(serializeMovementRequest(populated));
   })
 );
@@ -563,11 +617,6 @@ router.post(
     request.rejectedReason = null;
     await request.save();
     await addMovementLog(request.id, 'resubmitted', req.user.id, requestMetadata(req));
-    await recordAuditEvent({
-      action: 'Solicitud de movimiento',
-      request: 'Reenvío de solicitud',
-      user: req.user?.username || 'Desconocido'
-    });
     const populated = await request.populate([
       'item',
       { path: 'requestedBy', populate: 'role' },
@@ -575,6 +624,12 @@ router.post(
       'fromLocation',
       'toLocation'
     ]);
+    await recordAuditEvent({
+      action: 'Solicitud de movimiento',
+      request: buildMovementAuditSummary('Reenvío de solicitud', populated),
+      user: req.user?.username || 'Desconocido',
+      details: buildMovementAuditDetails(populated, 'Reenvío de solicitud')
+    });
     res.json(serializeMovementRequest(populated));
   })
 );

--- a/backend/src/services/auditService.js
+++ b/backend/src/services/auditService.js
@@ -10,7 +10,14 @@ function normalizeText(value, { fallback = '' } = {}) {
   return String(value).trim();
 }
 
-async function recordAuditEvent({ action, request, user }) {
+function normalizeDetails(value) {
+  if (value === undefined || value === null || typeof value !== 'object') {
+    return {};
+  }
+  return value;
+}
+
+async function recordAuditEvent({ action, request, user, details }) {
   const actionValue = normalizeText(action);
   const requestValue = normalizeText(request);
   const userValue = normalizeText(user, { fallback: 'Desconocido' });
@@ -22,7 +29,8 @@ async function recordAuditEvent({ action, request, user }) {
   await AuditLog.create({
     action: actionValue,
     request: requestValue,
-    user: userValue
+    user: userValue,
+    details: normalizeDetails(details)
   });
 }
 

--- a/frontend/src/pages/audit/AuditLogsPage.jsx
+++ b/frontend/src/pages/audit/AuditLogsPage.jsx
@@ -11,6 +11,179 @@ const ACTION_LABELS = {
   Autenticación: 'Autenticación'
 };
 
+const DETAIL_LABELS = {
+  item: 'Artículo',
+  movementRequest: 'Solicitud de movimiento',
+  changes: 'Cambios',
+  id: 'ID',
+  code: 'Código',
+  sku: 'SKU',
+  description: 'Descripción',
+  groupId: 'ID grupo',
+  groupName: 'Grupo',
+  attributes: 'Atributos',
+  stock: 'Stock',
+  unitsPerBox: 'Unidades por caja',
+  precio: 'Precio',
+  needsRecount: 'Requiere recuento',
+  imageCount: 'Cantidad de imágenes',
+  itemId: 'ID artículo',
+  type: 'Tipo',
+  fromLocationId: 'ID origen',
+  fromLocation: 'Origen',
+  toLocationId: 'ID destino',
+  toLocation: 'Destino',
+  quantity: 'Cantidad',
+  reason: 'Motivo',
+  requestedBy: 'Solicitado por',
+  requestedAt: 'Fecha de solicitud',
+  status: 'Estado',
+  approvedBy: 'Aprobado por',
+  approvedAt: 'Fecha de aprobación',
+  executedAt: 'Fecha de ejecución',
+  rejectedReason: 'Motivo de rechazo',
+  rejectionReason: 'Motivo de rechazo',
+  before: 'Antes',
+  after: 'Después',
+  boxes: 'Cajas',
+  units: 'Unidades',
+  name: 'Nombre',
+  email: 'Email',
+  role: 'Rol',
+  summary: 'Resumen',
+  ubicacion: 'Ubicación',
+  cantidad: 'Cantidad'
+};
+
+const MOVEMENT_TYPE_LABELS = {
+  ingress: 'Ingreso',
+  egress: 'Egreso',
+  transfer: 'Transferencia'
+};
+
+const STATUS_LABELS = {
+  pending: 'Pendiente',
+  approved: 'Aprobada',
+  rejected: 'Rechazada',
+  executed: 'Ejecutada'
+};
+
+const labelFor = key => DETAIL_LABELS[key] || key;
+
+const HIDDEN_DETAIL_KEYS = new Set([
+  'summary',
+  'id',
+  'itemId',
+  'fromLocationId',
+  'toLocationId',
+  'groupId',
+  'roleId',
+  'sku',
+  'boxes',
+  'units'
+]);
+
+const isPlainObject = value => value && typeof value === 'object' && !Array.isArray(value);
+
+const hasDetails = details => isPlainObject(details) && Object.keys(details).length > 0;
+
+const sanitizeAuditText = value => {
+  if (typeof value !== 'string') {
+    return value || '';
+  }
+  return value.replace(/\b[0-9a-f]{24}\s*:\s*/gi, 'Ubicación: ');
+};
+
+const isQuantity = value =>
+  isPlainObject(value) &&
+  Object.prototype.hasOwnProperty.call(value, 'boxes') &&
+  Object.prototype.hasOwnProperty.call(value, 'units') &&
+  Object.keys(value).every(key => ['boxes', 'units'].includes(key));
+
+const formatPrimitive = (key, value) => {
+  if (value === null || value === undefined || value === '') {
+    return '-';
+  }
+  if (typeof value === 'boolean') {
+    return value ? 'Sí' : 'No';
+  }
+  if (key === 'type' && MOVEMENT_TYPE_LABELS[value]) {
+    return MOVEMENT_TYPE_LABELS[value];
+  }
+  if (key === 'status' && STATUS_LABELS[value]) {
+    return STATUS_LABELS[value];
+  }
+  if (typeof value === 'string' && /At$/.test(key)) {
+    const date = new Date(value);
+    if (!Number.isNaN(date.getTime())) {
+      return date.toLocaleString('es-AR');
+    }
+  }
+  return String(value);
+};
+
+function renderAuditDetailValue(value, keyPrefix) {
+  if (isQuantity(value)) {
+    return `${Number(value.boxes) || 0} caja(s), ${Number(value.units) || 0} unidad(es)`;
+  }
+  if (Array.isArray(value)) {
+    if (value.length === 0) {
+      return '-';
+    }
+    return (
+      <ul style={{ margin: '0.25rem 0 0', paddingLeft: '1.1rem' }}>
+        {value.map((entry, index) => {
+          const friendlyStockEntry = isPlainObject(entry) && entry.ubicacion && entry.cantidad
+            ? `${entry.ubicacion}: ${entry.cantidad}`
+            : null;
+          return (
+            <li key={`${keyPrefix}-${index}`}>
+              {friendlyStockEntry || renderAuditDetailValue(entry, `${keyPrefix}-${index}`)}
+            </li>
+          );
+        })}
+      </ul>
+    );
+  }
+  if (isPlainObject(value)) {
+    const entries = Object.entries(value).filter(
+      ([entryKey, entryValue]) => entryValue !== undefined && !HIDDEN_DETAIL_KEYS.has(entryKey)
+    );
+    if (entries.length === 0) {
+      return '-';
+    }
+    return (
+      <dl style={{ margin: '0.25rem 0 0', display: 'grid', gap: '0.35rem' }}>
+        {entries.map(([entryKey, entryValue]) => (
+          <div key={`${keyPrefix}-${entryKey}`} style={{ display: 'grid', gap: '0.1rem' }}>
+            <dt style={{ color: '#475569', fontWeight: 700 }}>{labelFor(entryKey)}</dt>
+            <dd style={{ margin: 0 }}>{renderAuditDetailValue(entryValue, `${keyPrefix}-${entryKey}`)}</dd>
+          </div>
+        ))}
+      </dl>
+    );
+  }
+  return formatPrimitive(keyPrefix.split('-').pop(), value);
+}
+
+function AuditDetails({ details, fallback }) {
+  if (!hasDetails(details)) {
+    const sanitizedFallback = sanitizeAuditText(fallback);
+    const fallbackText = typeof sanitizedFallback === 'string' && /[:|]/.test(sanitizedFallback) ? sanitizedFallback : '';
+    return (
+      <span style={{ color: fallbackText ? '#334155' : '#94a3b8' }}>
+        {fallbackText || 'Detalle estructurado no disponible'}
+      </span>
+    );
+  }
+  return (
+    <details>
+      <summary style={{ cursor: 'pointer', color: '#2563eb', fontWeight: 700 }}>Ver detalle</summary>
+      <div style={{ marginTop: '0.5rem', maxWidth: '42rem' }}>{renderAuditDetailValue(details, 'details')}</div>
+    </details>
+  );
+}
+
 const getDefaultDateRange = () => {
   const to = new Date();
   const from = new Date();
@@ -42,6 +215,7 @@ export default function AuditLogsPage() {
   const [logs, setLogs] = useState([]);
   const [filters, setFilters] = useState(() => ({
     request: '',
+    item: '',
     user: '',
     limit: 100,
     action: '',
@@ -72,6 +246,9 @@ export default function AuditLogsPage() {
         if (filters.request) {
           query.request = filters.request;
         }
+        if (filters.item) {
+          query.item = filters.item;
+        }
         if (filters.user) {
           query.user = filters.user;
         }
@@ -99,7 +276,7 @@ export default function AuditLogsPage() {
     return () => {
       active = false;
     };
-  }, [api, canViewLogs, filters.action, filters.from, filters.limit, filters.request, filters.to, filters.user]);
+  }, [api, canViewLogs, filters.action, filters.from, filters.item, filters.limit, filters.request, filters.to, filters.user]);
 
   if (!canViewLogs) {
     return <ErrorMessage error="No tiene permisos para acceder a la auditoría." />;
@@ -132,12 +309,21 @@ export default function AuditLogsPage() {
             </select>
           </div>
           <div className="input-group">
-            <label htmlFor="requestFilter">Detalle</label>
+            <label htmlFor="requestFilter">Operación</label>
             <input
               id="requestFilter"
               value={filters.request}
               onChange={event => setFilters(prev => ({ ...prev, request: event.target.value }))}
-              placeholder="Ej.: Alta de artículo"
+              placeholder="Ej.: Alta, baja, aprobación"
+            />
+          </div>
+          <div className="input-group">
+            <label htmlFor="itemFilter">Artículo</label>
+            <input
+              id="itemFilter"
+              value={filters.item}
+              onChange={event => setFilters(prev => ({ ...prev, item: event.target.value }))}
+              placeholder="Código o descripción del artículo"
             />
           </div>
           <div className="input-group">
@@ -192,6 +378,7 @@ export default function AuditLogsPage() {
                   <th>Fecha</th>
                   <th>Acción</th>
                   <th>Detalle</th>
+                  <th>Datos registrados</th>
                   <th>Usuario</th>
                 </tr>
               </thead>
@@ -200,13 +387,14 @@ export default function AuditLogsPage() {
                   <tr key={log.id}>
                     <td>{new Date(log.timestamp).toLocaleString('es-AR')}</td>
                     <td>{getActionLabel(log.action)}</td>
-                    <td>{log.request || '-'}</td>
+                    <td>{sanitizeAuditText(log.request) || '-'}</td>
+                    <td><AuditDetails details={log.details} fallback={log.request} /></td>
                     <td>{log.user || '-'}</td>
                   </tr>
                 ))}
                 {logs.length === 0 && (
                   <tr>
-                    <td colSpan={4} style={{ textAlign: 'center', padding: '1.5rem 0' }}>
+                    <td colSpan={5} style={{ textAlign: 'center', padding: '1.5rem 0' }}>
                       No se encontraron registros.
                     </td>
                   </tr>


### PR DESCRIPTION
### Motivation

- Provide structured audit data for item and movement operations so audit logs are searchable, filterable, and display friendly summaries. 
- Improve visibility of what changed during item updates and movement request lifecycle events by capturing snapshots and diffs. 
- Surface structured details in the frontend audit viewer and allow filtering by item identifier.

### Description

- Extend the audit model with a `details` field (`Schema.Types.Mixed`) and update `recordAuditEvent` in `backend/src/services/auditService.js` to accept and normalize `details`. 
- Add item audit helpers in `backend/src/routes/items.js` to build friendly stock/attribute snapshots, summaries and change diffs, and include these as `details` when recording audit events for create/update/delete item flows. 
- Add movement audit helpers in `backend/src/routes/stock.js` to build human-friendly movement summaries and detailed payloads, populate movement requests with related entities, and include those `details` when recording audit events for create/approve/reject/resubmit/delete movement request flows. 
- Enhance `backend/src/routes/logs.js` to accept an `item` query parameter to search inside `request` and `details` fields and to return the `details` object in the API response. 
- Update frontend `backend/src/...` UI in `frontend/src/pages/audit/AuditLogsPage.jsx` to show structured `details` with labels, render quantities and nested objects, add an `Artículo` filter, display a dedicated column for registered data, and sanitize/format textual fallback summaries.

### Testing

- Ran the project's backend test and lint commands (`npm test`, `npm run lint`) and the frontend build (`npm run build`) locally and they completed successfully. 
- Exercised key API flows in development (item create/update/delete and movement request create/approve/reject/resubmit/delete) to validate audit entries include `details` and that the frontend renders them without errors. 
- Verified the `GET /logs/audit` endpoint accepts the new `item` filter and returns `details` in responses during manual integration checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdd5acca28832a9f6af3b5bbc7342f)