### PR TITLE
Add Supervisor role and enforce corresponding frontend permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Una vez liberado el puerto, vuelve a iniciar el servicio con `pm2 start` o `pm2 
 
 ### Credenciales iniciales
 
-Al primer arranque se crean los roles `Administrador`, `Operador` y `Consulta`, junto con un usuario administrador activo:
+Al primer arranque se crean los roles `Administrador`, `Operador`, `Supervisor` y `Consulta`, junto con un usuario administrador activo:
 
 - **Usuario**: valor de `ADMIN_EMAIL` (por defecto `admin@example.com`)
 - **Contraseña**: valor de `ADMIN_PASSWORD` (por defecto `ChangeMe123!`)

--- a/SPEC.md
+++ b/SPEC.md
@@ -32,7 +32,7 @@ Desarrollar un sistema de gestión de inventario enfocado en depósitos configur
   - Registro automático de logs (requested/approved/executed/rejected).
 - **ABM de Usuarios**:
   - Crear/editar/deshabilitar usuarios y asignar roles.
-  - Roles base: **Administrador**, **Operador**, **Consulta** (extensible con permisos granulares).
+  - Roles base: **Administrador**, **Operador**, **Supervisor**, **Consulta** (extensible con permisos granulares).
 - **Reportes**:
   - Stock consolidado por grupo (detalle por artículo y depósito).
   - Stock consolidado por depósito (detalle por artículo).

--- a/backend/docs/sample-dataset.json
+++ b/backend/docs/sample-dataset.json
@@ -121,6 +121,17 @@
         },
         {
             "_id": {
+                "$oid": "b7c8d9e0f1a2b3c4d5e6f708"
+            },
+            "name": "Supervisor",
+            "permissions": [
+                "items.read",
+                "stock.request",
+                "reports.read"
+            ]
+        },
+        {
+            "_id": {
                 "$oid": "4152a60c794d16a7358206b9"
             },
             "name": "Consulta",

--- a/backend/src/seed.js
+++ b/backend/src/seed.js
@@ -24,6 +24,10 @@ const defaultRoles = [
     permissions: ['items.read', 'items.write', 'stock.request', 'reports.read']
   },
   {
+    name: 'Supervisor',
+    permissions: ['items.read', 'stock.request', 'reports.read']
+  },
+  {
     name: 'Consulta',
     permissions: ['items.read', 'reports.read']
   }

--- a/frontend/src/pages/items/ItemsPage.jsx
+++ b/frontend/src/pages/items/ItemsPage.jsx
@@ -873,8 +873,9 @@ export default function ItemsPage() {
         </div>
       )}
 
-      <div className="section-card">
-        <form className="item-form" onSubmit={handleSubmit}>
+      {canWrite ? (
+        <div className="section-card">
+          <form className="item-form" onSubmit={handleSubmit}>
           <section className="form-section">
             <div className="form-section__header">
               <div>
@@ -1142,8 +1143,20 @@ export default function ItemsPage() {
               )}
             </div>
           </div>
-        </form>
-      </div>
+          </form>
+        </div>
+      ) : (
+        <div className="section-card">
+          <div className="flex-between">
+            <div>
+              <h2>Consulta de artículos</h2>
+              <p style={{ color: '#475569', margin: 0 }}>
+                Tu rol permite buscar datos, revisar cantidades e imágenes, pero no crear, editar ni eliminar artículos.
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
 
       <div className="section-card">
         <div className="flex-between">

--- a/frontend/src/pages/movements/MovementRequestsPage.jsx
+++ b/frontend/src/pages/movements/MovementRequestsPage.jsx
@@ -36,10 +36,10 @@ export default function MovementRequestsPage() {
   const { user } = useAuth();
   const permissions = useMemo(() => user?.permissions || [], [user]);
   const isAdmin = user?.role === 'Administrador';
-  const isOperator = user?.role === 'Operador';
+  const hasRestrictedRequesterRole = ['Operador', 'Supervisor'].includes(user?.role);
   const hasRequestPermission = permissions.includes('stock.request');
   const canRequest = hasRequestPermission;
-  const isOperatorWithRestrictions = isOperator && hasRequestPermission;
+  const hasRequesterRestrictions = hasRestrictedRequesterRole && hasRequestPermission;
 
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -180,7 +180,7 @@ export default function MovementRequestsPage() {
       ORIGIN_PRIORITY.map((name, index) => [name.toLowerCase(), index])
     );
     const availableLocations = Array.isArray(locations) ? locations : [];
-    const allowedOriginTypes = isOperatorWithRestrictions
+    const allowedOriginTypes = hasRequesterRestrictions
       ? ['warehouse']
       : ['warehouse', 'externalOrigin'];
     return availableLocations
@@ -196,7 +196,7 @@ export default function MovementRequestsPage() {
         }
         return (a.name || '').localeCompare(b.name || '', 'es', { sensitivity: 'base' });
       });
-  }, [isOperatorWithRestrictions, locations]);
+  }, [hasRequesterRestrictions, locations]);
 
   const pendingMap = useMemo(() => aggregatePendingByItem(pendingSnapshot), [pendingSnapshot]);
 
@@ -436,12 +436,12 @@ export default function MovementRequestsPage() {
       const fromLocation = locationMap.get(String(formValues.fromLocation));
       const toLocation = locationMap.get(String(formValues.toLocation));
 
-      if (isOperatorWithRestrictions) {
+      if (hasRequesterRestrictions) {
         const isFromWarehouse = fromLocation?.type === 'warehouse';
         const isToAllowed = ['warehouse', 'external'].includes(toLocation?.type);
         if (!isFromWarehouse || !isToAllowed) {
           setError(
-            'Como operador solo puede solicitar transferencias desde depósitos internos hacia depósitos internos o externos.'
+            'Como operador o supervisor solo puede solicitar transferencias desde depósitos internos hacia depósitos internos o externos.'
           );
           setSubmitting(false);
           return;


### PR DESCRIPTION
### Motivation
- Introduce a `Supervisor` role to model a mid-level user that can request stock and read items/reports but not perform writes. 
- Ensure documentation, seeded data and UI behavior reflect the new role and that request/create flows apply the same restrictions for `Operador` and `Supervisor`.

### Description
- Add the `Supervisor` role with permissions `items.read`, `stock.request`, `reports.read` in `backend/src/seed.js` and `backend/docs/sample-dataset.json`.
- Update `README.md` and `SPEC.md` to list the `Supervisor` role in the initial credentials and roles sections.
- Change `frontend/src/pages/items/ItemsPage.jsx` to hide the item create/edit form when the user lacks write permission and show a read-only informational card instead.
- Update `frontend/src/pages/movements/MovementRequestsPage.jsx` to treat `Supervisor` like `Operador` for origin/destination restrictions, rename variables for clarity, and adjust the user-facing error message.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05eba39ba0832aaba73e6ee7588c88)