### PR TITLE
Quitar SKU informativo en edición de artículos

### DIFF
--- a/frontend/src/pages/items/ItemsPage.jsx
+++ b/frontend/src/pages/items/ItemsPage.jsx
@@ -900,12 +900,6 @@ export default function ItemsPage() {
                   />
                 </div>
               )}
-              {editingItem && (
-                <div className="input-group">
-                  <label htmlFor="sku">SKU</label>
-                  <input id="sku" name="sku" value={editingItem.sku || ''} readOnly disabled />
-                </div>
-              )}
               <div className="input-group">
                 <label htmlFor="description">Descripción *</label>
                 <input


### PR DESCRIPTION
### Motivation
- Simplificar el formulario de edición eliminando el campo `SKU` solo informativo para que la edición muestre directamente los campos editables.

### Description
- Se eliminó el bloque de entrada de solo lectura del `SKU` en `frontend/src/pages/items/ItemsPage.jsx` para que al editar un artículo no se muestre ese campo.

### Testing
- Ejecutado `npm run build` en `frontend` y la compilación completó con éxito.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05f368cbc8832a949dd9e204e40c4f)