### PR TITLE
Fix deleted groups being recreated on backend startup

### DIFF
--- a/backend/src/seed.js
+++ b/backend/src/seed.js
@@ -65,11 +65,13 @@ async function seedRoles() {
 }
 
 async function seedGroups() {
+  const hasAnyGroup = await Group.exists({});
+  if (hasAnyGroup) {
+    return;
+  }
+
   for (const name of defaultGroups) {
-    const existing = await Group.findOne({ name });
-    if (!existing) {
-      await Group.create({ name });
-    }
+    await Group.create({ name });
   }
 }
 


### PR DESCRIPTION
### Motivation
- Al reiniciar el backend los grupos por defecto que faltaban se volvían a crear automáticamente, haciendo que grupos borrados manualmente reaparezcan.
- Era necesario evitar que el proceso de seed resembrara los grupos por defecto si la colección ya contiene datos.

### Description
- Cambiado `seedGroups` en `backend/src/seed.js` para comprobar si existe al menos un grupo usando `Group.exists({})` y salir si la colección no está vacía.
- Eliminada la verificación y recreación individual de cada nombre por defecto y reemplazada por un bucle que solo se ejecuta cuando no hay grupos.
- Con este cambio los grupos por defecto solo se crean en bases de datos nuevas y no vuelven a aparecer tras borrados manuales.

### Testing
- Ejecutado `cd backend && npm test`, que se completa correctamente (el proyecto indica que no hay pruebas automatizadas definidas).
- La ejecución mostró una advertencia de npm `Unknown env config "http-proxy"` pero no impidió la validación del cambio.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c6d5e7e10832a9aaf1a0758178ff1)