### PR TITLE
Add 10×10 cm barcode label printing (hidden iframe) and Windows kiosk print script

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,3 +261,18 @@ El script se encargará de:
   disponible, el script generará el paquete y omitirá el arranque de servicios automáticamente).
 
 Para más detalles y opciones avanzadas (`--mongo-mode`, `--backend-port`, etc.), revisa la guía [`docs/demo-deployment.md`](docs/demo-deployment.md).
+
+### Impresión directa de etiquetas 10 × 10 cm en Windows
+
+La pantalla de etiquetas imprime cada EAN-13 en una página física de 100 × 100 mm. Para enviar el trabajo sin mostrar la selección de impresoras:
+
+1. Configura la **XP-450B como impresora predeterminada de Windows** y define en su controlador un papel de **100 × 100 mm**, orientación vertical, márgenes en cero y escala 100 %.
+2. Inicia el frontend normalmente.
+3. Abre la aplicación con `scripts\iniciar_impresion_directa.bat`. El script inicia Microsoft Edge o Google Chrome con `--kiosk-printing`, por lo que el botón de impresión utiliza directamente la impresora predeterminada.
+4. Si el frontend usa otra dirección, pásala como primer argumento, por ejemplo:
+
+   ```bat
+   scripts\iniciar_impresion_directa.bat http://192.168.1.20:4173/items/download
+   ```
+
+Sin `--kiosk-printing`, los navegadores muestran obligatoriamente su diálogo de impresión. La aplicación genera el trabajo en un marco oculto y no abre una pestaña o ventana adicional.

--- a/frontend/src/pages/items/ItemsDownloadPage.jsx
+++ b/frontend/src/pages/items/ItemsDownloadPage.jsx
@@ -195,6 +195,44 @@ function buildEan13SvgMarkup(ean13) {
   `;
 }
 
+
+function printHtmlInHiddenFrame(html) {
+  return new Promise((resolve, reject) => {
+    const printFrame = document.createElement('iframe');
+    printFrame.setAttribute('aria-hidden', 'true');
+    printFrame.style.position = 'fixed';
+    printFrame.style.width = '0';
+    printFrame.style.height = '0';
+    printFrame.style.border = '0';
+
+    const removeFrame = () => {
+      if (printFrame.parentNode) {
+        printFrame.parentNode.removeChild(printFrame);
+      }
+    };
+
+    printFrame.onload = () => {
+      try {
+        const frameWindow = printFrame.contentWindow;
+        if (!frameWindow) {
+          throw new Error('No se pudo preparar el documento de impresión.');
+        }
+        frameWindow.addEventListener('afterprint', removeFrame, { once: true });
+        frameWindow.focus();
+        frameWindow.print();
+        window.setTimeout(removeFrame, 60000);
+        resolve();
+      } catch (error) {
+        removeFrame();
+        reject(error);
+      }
+    };
+
+    printFrame.srcdoc = html;
+    document.body.appendChild(printFrame);
+  });
+}
+
 export default function ItemsDownloadPage() {
   const api = useApi();
   const { user } = useAuth();
@@ -350,33 +388,8 @@ export default function ItemsDownloadPage() {
     selectVisibleItemsForPrint();
   }, [clearSelectionForPrint, selectVisibleItemsForPrint, visibleSelectionState.allSelected, visibleSelectionState.someSelected]);
 
-  const handlePrintLabelsA4 = async itemsToPrint => {
+  const handlePrintLabels100x100 = async itemsToPrint => {
     if (printing) return;
-    const printWindow = window.open('', '_blank');
-    if (!printWindow) {
-      setError(new Error('No se pudo abrir la ventana de impresión. Verificá si el navegador bloqueó la ventana emergente.'));
-      return;
-    }
-
-    printWindow.document.open();
-    printWindow.document.write(`
-      <!doctype html>
-      <html lang="es">
-        <head>
-          <meta charset="utf-8" />
-          <title>Preparando impresión…</title>
-          <style>
-            body { font-family: Arial, sans-serif; margin: 24px; color: #0f172a; }
-            p { color: #334155; }
-          </style>
-        </head>
-        <body>
-          <h1>Preparando impresión…</h1>
-          <p>Estamos generando el listado de artículos seleccionados. Este proceso puede tardar unos segundos.</p>
-        </body>
-      </html>
-    `);
-    printWindow.document.close();
 
     setPrinting(true);
     setError(null);
@@ -385,11 +398,6 @@ export default function ItemsDownloadPage() {
       if (collectedItems.length === 0) {
         throw new Error('Seleccioná al menos un artículo para generar etiquetas.');
       }
-
-      const printedAt = new Date().toLocaleString('es-AR', {
-        dateStyle: 'short',
-        timeStyle: 'short'
-      });
 
       const labelCards = collectedItems
         .map(item => {
@@ -409,133 +417,90 @@ export default function ItemsDownloadPage() {
         <html lang="es">
           <head>
             <meta charset="utf-8" />
-            <title>Artículos seleccionados</title>
+            <title>Etiquetas 10 × 10 cm</title>
             <style>
-              body { font-family: Arial, sans-serif; margin: 24px; color: #0f172a; }
-              h1 { margin: 0 0 8px; font-size: 22px; }
-              p { margin: 0 0 6px; color: #334155; }
-              .meta { margin-bottom: 14px; }
-              .labels-grid {
-                display: grid;
-                grid-template-columns: repeat(3, 63mm);
-                grid-auto-rows: 33.9mm;
-                gap: 2mm;
-                align-content: start;
+              @page { size: 100mm 100mm; margin: 0; }
+              * { box-sizing: border-box; }
+              html, body {
+                margin: 0 !important;
+                padding: 0 !important;
+                width: 100mm;
+                font-family: Arial, sans-serif;
+                color: #000;
+                background: #fff;
               }
               .label-card {
-                border: 1px dashed #cbd5e1;
-                border-radius: 2mm;
-                padding: 2mm;
+                width: 99mm;
+                height: 99mm;
+                margin: 0;
+                padding: 0;
+                transform: translate(0.5mm, 0.5mm);
                 display: flex;
                 flex-direction: column;
                 justify-content: center;
                 align-items: center;
                 overflow: hidden;
+                background: #fff;
+                break-after: page;
+                page-break-after: always;
+                break-inside: avoid;
+                page-break-inside: avoid;
               }
-              .barcode-wrap { width: 100%; }
+              .label-card:last-child {
+                break-after: auto;
+                page-break-after: auto;
+              }
+              .barcode-wrap {
+                width: 58.8mm;
+                height: 32.2mm;
+                display: flex;
+                justify-content: center;
+                align-items: center;
+                flex: 0 0 auto;
+              }
               .barcode-svg {
                 display: block;
-                width: 100%;
-                max-height: 22mm;
+                width: 58.8mm;
+                height: 32.2mm;
               }
               .ean-text {
-                margin: 1.8mm 0 0;
-                letter-spacing: 0.5px;
-                font-size: 12px;
-                color: #0f172a;
-                font-weight: 600;
+                margin: 2.8mm 0 0;
+                color: #000;
+                font-size: 12.6pt;
+                font-weight: 700;
+                letter-spacing: 0.84mm;
+                line-height: 1;
+                text-align: center;
+                flex: 0 0 auto;
               }
               .barcode-error {
-                width: 100%;
-                border: 1px solid #fca5a5;
-                background: #fef2f2;
-                color: #991b1b;
-                font-size: 12px;
+                width: 58.8mm;
+                border: 0.5mm solid #000;
+                color: #000;
+                font-size: 12.6pt;
+                font-weight: 700;
                 text-align: center;
-                border-radius: 4px;
-                padding: 8px;
-              }
-              @media print {
-                @page { size: A4 portrait; margin: 10mm; }
-                body { margin: 0; }
-                .label-card {
-                  break-inside: avoid;
-                  page-break-inside: avoid;
-                }
+                padding: 4mm;
               }
             </style>
           </head>
           <body>
-            <h1>Listado de artículos seleccionados</h1>
-            <div class="meta">
-              <p><strong>Total:</strong> ${collectedItems.length}</p>
-              <p><strong>Fecha de impresión:</strong> ${escapeHtml(printedAt)}</p>
-            </div>
-            <section class="labels-grid">
-              ${
-                labelCards ||
-                '<div class="barcode-error">No hay artículos seleccionados para imprimir.</div>'
-              }
-            </section>
+            ${labelCards}
           </body>
         </html>
       `;
 
-      printWindow.document.open();
-      printWindow.document.write(printableContent);
-      printWindow.document.close();
-
-      const triggerPrint = () => {
-        printWindow.focus();
-        printWindow.print();
-      };
-
-      if (printWindow.document.readyState === 'complete') {
-        triggerPrint();
-      } else {
-        printWindow.onload = () => {
-          triggerPrint();
-        };
-      }
+      await printHtmlInHiddenFrame(printableContent);
     } catch (err) {
       setError(err);
-      printWindow.document.open();
-      printWindow.document.write(`
-        <!doctype html>
-        <html lang="es">
-          <head>
-            <meta charset="utf-8" />
-            <title>Error al imprimir</title>
-          </head>
-          <body>
-            <h1>No se pudo generar la impresión</h1>
-            <p>${escapeHtml(err?.message || 'Ocurrió un error inesperado.')}</p>
-          </body>
-        </html>
-      `);
-      printWindow.document.close();
     } finally {
       setPrinting(false);
     }
   };
 
-  const handlePrintConfirm = useCallback(
-    itemsToPrint => {
-      const selectedCount = Array.isArray(itemsToPrint) ? itemsToPrint.length : 0;
-      if (selectedCount === 0) {
-        setError(new Error('Seleccioná al menos un artículo para generar etiquetas.'));
-        return;
-      }
-      const confirmed = window.confirm(
-        `Se imprimirán ${selectedCount} etiqueta(s) en formato A4.\n\n¿Deseás continuar?`
-      );
-      if (!confirmed) {
-        return;
-      }
-      handlePrintLabelsA4(itemsToPrint);
-    },
-    [handlePrintLabelsA4]
-  );
+  const handlePrintSelectedLabels = useCallback(() => {
+    handlePrintLabels100x100(selectedItemsList);
+  }, [handlePrintLabels100x100, selectedItemsList]);
 
   const handlePrintSingleLabel = useCallback(
     item => {
@@ -547,9 +512,9 @@ export default function ItemsDownloadPage() {
         description: item.description || '-'
       };
       setSelectedItemsForPrint(prev => ({ ...prev, [item.id]: singleItemPayload }));
-      handlePrintConfirm([singleItemPayload]);
+      handlePrintLabels100x100([singleItemPayload]);
     },
-    [handlePrintConfirm]
+    [handlePrintLabels100x100]
   );
 
   const handleDownloadSelectedPdf = async () => {
@@ -662,7 +627,7 @@ export default function ItemsDownloadPage() {
         <div>
           <h2>Descarga de artículos</h2>
           <p style={{ color: '#475569', marginTop: '-0.4rem' }}>
-            Seleccioná artículos y generá el PDF desde esta pantalla específica.
+            Seleccioná artículos para descargar el PDF o imprimir etiquetas de código de barras de 10 × 10 cm.
           </p>
         </div>
         <div>
@@ -674,7 +639,7 @@ export default function ItemsDownloadPage() {
 
       <div className="section-card">
         <div className="flex-between">
-          <h2>Buscar artículos para descarga</h2>
+          <h2>Buscar artículos para descarga o impresión</h2>
           <div className="inline-actions">
             <button
               type="button"
@@ -688,11 +653,11 @@ export default function ItemsDownloadPage() {
             <button
               type="button"
               className="secondary-button"
-              onClick={() => handlePrintConfirm(selectedItemsList)}
+              onClick={handlePrintSelectedLabels}
               disabled={printing || selectedItemsList.length === 0}
-              title={selectedItemsList.length === 0 ? 'Seleccioná artículos para habilitar la descarga.' : undefined}
+              title={selectedItemsList.length === 0 ? 'Seleccioná artículos para habilitar la impresión.' : 'Imprime una etiqueta de 10 × 10 cm por cada artículo seleccionado.'}
             >
-              {printing ? 'Preparando impresión…' : 'Imprimir etiquetas A4'}
+              {printing ? 'Preparando impresión…' : 'Imprimir etiquetas 10 × 10'}
             </button>
           </div>
         </div>
@@ -786,10 +751,10 @@ export default function ItemsDownloadPage() {
         <div className="flex-between" style={{ marginTop: '0.75rem', gap: '0.75rem', alignItems: 'center' }}>
           <div>
             <span style={{ color: '#475569', fontSize: '0.9rem' }}>
-              Seleccionados para descarga: <strong>{selectedItemsList.length}</strong>
+              Seleccionados: <strong>{selectedItemsList.length}</strong>
             </span>
             <p style={{ margin: '0.15rem 0 0', color: '#64748b', fontSize: '0.78rem' }}>
-              Podés marcar artículo por artículo con el check de cada línea (columna Descargar).
+              Podés marcar uno o varios artículos para descargar el PDF o imprimir una etiqueta por código.
             </p>
           </div>
           <div className="inline-actions">
@@ -825,7 +790,7 @@ export default function ItemsDownloadPage() {
             <table>
               <thead>
                 <tr>
-                  <th>Descargar</th>
+                  <th>Seleccionar</th>
                   <th>EAN13</th>
                   <th>Artículo</th>
                   <th>Descripción</th>
@@ -841,8 +806,8 @@ export default function ItemsDownloadPage() {
                           type="checkbox"
                           checked={isSelectedForPrint(item.id)}
                           onChange={() => toggleItemSelectionForPrint(item)}
-                          title="Seleccionar esta línea para PDF"
-                          aria-label={`Seleccionar ${item.code || 'artículo'} para PDF`}
+                          title="Seleccionar esta línea para PDF o impresión"
+                          aria-label={`Seleccionar ${item.code || 'artículo'} para PDF o impresión`}
                         />
                       </td>
                       <td>{buildItemEan13(item.sku, item.unitsPerBox) || '-'}</td>

--- a/scripts/iniciar_impresion_directa.bat
+++ b/scripts/iniciar_impresion_directa.bat
@@ -1,0 +1,19 @@
+@echo off
+setlocal
+
+rem La XP-450B debe estar configurada como impresora predeterminada de Windows.
+set "APP_URL=http://localhost:4173/items/download"
+if not "%~1"=="" set "APP_URL=%~1"
+
+set "BROWSER=%ProgramFiles(x86)%\Microsoft\Edge\Application\msedge.exe"
+if not exist "%BROWSER%" set "BROWSER=%ProgramFiles%\Microsoft\Edge\Application\msedge.exe"
+if not exist "%BROWSER%" set "BROWSER=%ProgramFiles%\Google\Chrome\Application\chrome.exe"
+if not exist "%BROWSER%" set "BROWSER=%LocalAppData%\Google\Chrome\Application\chrome.exe"
+
+if not exist "%BROWSER%" (
+  echo No se encontro Microsoft Edge ni Google Chrome.
+  exit /b 1
+)
+
+start "GestionThibe - impresion directa" "%BROWSER%" --user-data-dir="%TEMP%\GestionThibePrintProfile" --no-first-run --app="%APP_URL%" --kiosk-printing
+endlocal


### PR DESCRIPTION
### Motivation

- Provide a dedicated 10 × 10 cm label printing mode for EAN-13 codes that prints one label per physical page and can be sent directly to a configured Windows printer without user print dialogs. 

### Description

- Implemented `printHtmlInHiddenFrame` in `ItemsDownloadPage.jsx` and replaced the previous A4 popup-based printing flow with a hidden iframe flow that triggers `print()` and removes the frame after printing. 
- Changed printable HTML/CSS to set `@page { size: 100mm 100mm }` and layout each label as a single 99×99 mm card with page-break rules and adjusted barcode/typography sizing and semantics. 
- Updated UI copy and controls in `ItemsDownloadPage.jsx` to reflect selection/printing for 10 × 10 cm labels and wired `handlePrintLabels100x100` / `handlePrintSelectedLabels` flows, while preserving PDF download behavior. 
- Added Windows helper script `scripts/iniciar_impresion_directa.bat` and README instructions to launch the frontend in Chrome/Edge with `--kiosk-printing` for direct printing to a default-configured XP-450B printer. 

### Testing

- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a280c97b954832abff12ad22e1f4b37)