### PR TITLE
Add item trash (soft-delete) with scheduled purge, price tiers and recount UX improvements

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -2,6 +2,7 @@ const app = require('./app');
 const config = require('./config');
 const { connectDatabase } = require('./db');
 const seed = require('./seed');
+const { purgeExpiredItems } = require('./services/itemTrashService');
 
 
 
@@ -9,6 +10,11 @@ async function start() {
   try {
     await connectDatabase();
     await seed();
+    await purgeExpiredItems();
+    const purgeTimer = setInterval(() => {
+      purgeExpiredItems().catch(error => console.error('No se pudo purgar la papelera', error));
+    }, 60 * 60 * 1000);
+    purgeTimer.unref();
     app.listen(config.port, () => {
       console.log(`Servidor escuchando en http://localhost:${config.port}`);
     });

--- a/backend/src/models/Item.js
+++ b/backend/src/models/Item.js
@@ -3,6 +3,14 @@ const { Schema, model, Types } = require('mongoose');
 const { coerceQuantity } = require('../utils/quantity');
 const quantitySubSchema = require('./schemas/quantity');
 
+const priceTierSchema = new Schema(
+  {
+    minQuantity: { type: Number, required: true, min: 1 },
+    price: { type: Number, required: true, min: 0 }
+  },
+  { _id: false }
+);
+
 const itemSchema = new Schema(
   {
     code: { type: String, required: true, trim: true, unique: true },
@@ -19,7 +27,13 @@ const itemSchema = new Schema(
     stock: { type: Map, of: quantitySubSchema, default: () => ({}) },
     images: { type: [String], default: [] },
     needsRecount: { type: Boolean, default: false },
-    pDecimal: { type: Number, default: null }
+    pDecimal: { type: Number, default: null },
+    priceTiers: { type: [priceTierSchema], default: [] },
+    lastCountedAt: { type: Date, default: null },
+    lastCountedBy: { type: String, default: null, trim: true },
+    deletedAt: { type: Date, default: null, index: true },
+    deletedBy: { type: String, default: null, trim: true },
+    scheduledDeletionAt: { type: Date, default: null, index: true }
   },
   {
     timestamps: true,

--- a/backend/src/routes/items.js
+++ b/backend/src/routes/items.js
@@ -13,11 +13,13 @@ const { normalizeQuantityInput } = require('../services/stockService');
 const { recordAuditEvent } = require('../services/auditService');
 const { collectGroupAndDescendantIds, buildGroupFilterValues } = require('../services/groupService');
 const { assignSkuToNewItemData, ensureItemSkus } = require('../services/skuService');
+const { permanentlyDeleteItem } = require('../services/itemTrashService');
 
 const { promises: fsPromises } = fs;
 
 const MAX_IMAGES = 5;
 const MAX_FILE_SIZE = 5 * 1024 * 1024;
+const TRASH_RETENTION_DAYS = 30;
 const projectRoot = path.join(__dirname, '..', '..');
 const uploadsRoot = path.join(projectRoot, 'uploads');
 const itemUploadsDir = path.join(uploadsRoot, 'items');
@@ -294,6 +296,36 @@ function normalizePrecio(value, { fieldName = 'precio' } = {}) {
   return Math.round(numeric * 100) / 100;
 }
 
+function normalizePriceTiers(value, fallbackPrice) {
+  if (value === undefined) {
+    if (fallbackPrice === undefined || fallbackPrice === null) return undefined;
+    return [{ minQuantity: 1, price: fallbackPrice }];
+  }
+  if (!Array.isArray(value)) {
+    throw new HttpError(400, 'priceTiers debe ser una lista');
+  }
+  const seen = new Set();
+  const tiers = value.map((tier, index) => {
+    const minQuantity = Number(tier?.minQuantity);
+    if (!Number.isInteger(minQuantity) || minQuantity < 1) {
+      throw new HttpError(400, `Cantidad inválida en el precio ${index + 1}`);
+    }
+    if (seen.has(minQuantity)) {
+      throw new HttpError(400, `La cantidad x${minQuantity} está repetida`);
+    }
+    seen.add(minQuantity);
+    const price = normalizePrecio(tier?.price, { fieldName: `Precio x${minQuantity}` });
+    if (price === null || price === undefined) {
+      throw new HttpError(400, `El precio x${minQuantity} es obligatorio`);
+    }
+    return { minQuantity, price };
+  }).sort((a, b) => a.minQuantity - b.minQuantity);
+  if (tiers.length > 0 && tiers[0].minQuantity !== 1) {
+    throw new HttpError(400, 'Debe existir un precio desde x1');
+  }
+  return tiers;
+}
+
 function serializeItem(doc) {
   const group = doc.group;
   return {
@@ -311,6 +343,14 @@ function serializeItem(doc) {
     needsRecount: Boolean(doc.needsRecount),
     pDecimal: doc.pDecimal === undefined || doc.pDecimal === null ? null : Number(doc.pDecimal),
     precio: doc.pDecimal !== undefined && doc.pDecimal !== null ? Number(doc.pDecimal) : null,
+    priceTiers: Array.isArray(doc.priceTiers)
+      ? doc.priceTiers.map(tier => ({ minQuantity: Number(tier.minQuantity), price: Number(tier.price) }))
+      : [],
+    lastCountedAt: doc.lastCountedAt || null,
+    lastCountedBy: doc.lastCountedBy || null,
+    deletedAt: doc.deletedAt || null,
+    deletedBy: doc.deletedBy || null,
+    scheduledDeletionAt: doc.scheduledDeletionAt || null,
     createdAt: doc.createdAt,
     updatedAt: doc.updatedAt
   };
@@ -395,7 +435,12 @@ async function buildItemAuditSnapshot(doc) {
     stock: await buildFriendlyAuditStock(doc.stock),
     unitsPerBox: doc.unitsPerBox === undefined || doc.unitsPerBox === null ? null : Number(doc.unitsPerBox),
     precio: doc.pDecimal === undefined || doc.pDecimal === null ? null : Number(doc.pDecimal),
+    priceTiers: Array.isArray(doc.priceTiers)
+      ? doc.priceTiers.map(tier => ({ minQuantity: Number(tier.minQuantity), price: Number(tier.price) }))
+      : [],
     needsRecount: Boolean(doc.needsRecount),
+    lastCountedAt: doc.lastCountedAt || null,
+    lastCountedBy: doc.lastCountedBy || null,
     imageCount: Array.isArray(doc.images) ? doc.images.length : 0
   };
 }
@@ -479,7 +524,7 @@ router.get(
     const { page = '1', pageSize = '20', groupId, search, sku, gender, size, color } = req.query || {};
     const pageNumber = Math.max(parseInt(page, 10) || 1, 1);
     const limit = Math.min(Math.max(parseInt(pageSize, 10) || 20, 1), 200);
-    const filter = {};
+    const filter = { deletedAt: null };
     const normalizedGroupId = typeof groupId === 'string' ? groupId.trim() : '';
     if (normalizedGroupId) {
       const groupIds = await collectGroupAndDescendantIds(normalizedGroupId);
@@ -521,6 +566,104 @@ router.get(
   })
 );
 
+router.get(
+  '/trash',
+  requirePermission('items.write'),
+  asyncHandler(async (req, res) => {
+    const items = await Item.find({ deletedAt: { $ne: null } }).populate('group').sort({ deletedAt: -1 });
+    res.json({ items: items.map(serializeItem), retentionDays: TRASH_RETENTION_DAYS });
+  })
+);
+
+router.post(
+  '/recount/mark-all',
+  requirePermission('items.write'),
+  asyncHandler(async (req, res) => {
+    const filter = { deletedAt: null };
+    const [total, alreadyPending] = await Promise.all([
+      Item.countDocuments(filter),
+      Item.countDocuments({ ...filter, needsRecount: true })
+    ]);
+    await Item.updateMany({ ...filter, needsRecount: false }, { $set: { needsRecount: true } }, { timestamps: false });
+    const changed = total - alreadyPending;
+    await recordAuditEvent({
+      action: 'Recuento',
+      request: `Recuento total iniciado para ${total} artículo(s)`,
+      user: req.user?.username || 'Desconocido',
+      details: { total, alreadyPending, changed }
+    });
+    res.json({ total, alreadyPending, changed });
+  })
+);
+
+router.patch(
+  '/:id/recount',
+  requirePermission('items.write'),
+  asyncHandler(async (req, res) => {
+    const { id } = req.params;
+    if (!Types.ObjectId.isValid(id)) throw new HttpError(400, 'Artículo inválido');
+    const item = await Item.findOne({ _id: id, deletedAt: null });
+    if (!item) throw new HttpError(404, 'Artículo no encontrado');
+    const before = await buildItemAuditSnapshot(item);
+    if (Object.prototype.hasOwnProperty.call(req.body || {}, 'stock')) {
+      const nextStock = Object.fromEntries(
+        Object.entries(buildStock(req.body.stock)).filter(([, value]) => value !== null)
+      );
+      item.stock = nextStock;
+      item.markModified('stock');
+    }
+    item.needsRecount = false;
+    item.lastCountedAt = new Date();
+    item.lastCountedBy = req.user?.username || 'Desconocido';
+    await item.save();
+    const populated = await item.populate('group');
+    const after = await buildItemAuditSnapshot(populated);
+    await recordAuditEvent({
+      action: 'Recuento',
+      request: `Recuento confirmado: ${item.code} - ${item.description}`,
+      user: req.user?.username || 'Desconocido',
+      details: { itemId: item.id, before, after, changes: buildItemAuditChanges(before, after) }
+    });
+    res.json(serializeItem(populated));
+  })
+);
+
+router.post(
+  '/trash/:id/restore',
+  requirePermission('items.write'),
+  asyncHandler(async (req, res) => {
+    const { id } = req.params;
+    if (!Types.ObjectId.isValid(id)) throw new HttpError(400, 'Artículo inválido');
+    const item = await Item.findOne({ _id: id, deletedAt: { $ne: null } });
+    if (!item) throw new HttpError(404, 'Artículo no encontrado en la papelera');
+    item.deletedAt = null;
+    item.deletedBy = null;
+    item.scheduledDeletionAt = null;
+    await item.save();
+    const populated = await item.populate('group');
+    await recordAuditEvent({
+      action: 'Artículo',
+      request: `Restauración de artículo: ${item.code} - ${item.description}`,
+      user: req.user?.username || 'Desconocido',
+      details: { itemId: item.id, code: item.code }
+    });
+    res.json(serializeItem(populated));
+  })
+);
+
+router.delete(
+  '/trash/:id',
+  requirePermission('items.write'),
+  asyncHandler(async (req, res) => {
+    const { id } = req.params;
+    if (!Types.ObjectId.isValid(id)) throw new HttpError(400, 'Artículo inválido');
+    const item = await Item.findOne({ _id: id, deletedAt: { $ne: null } });
+    if (!item) throw new HttpError(404, 'Artículo no encontrado en la papelera');
+    await permanentlyDeleteItem(item, { user: req.user?.username || 'Desconocido' });
+    res.status(204).send();
+  })
+);
+
 router.post(
   '/',
   requirePermission('items.write'),
@@ -536,7 +679,8 @@ router.post(
       needsRecount,
       unitsPerBox,
       precio,
-      pDecimal
+      pDecimal,
+      priceTiers
     } = payload;
     if (!code || !description) {
       throw new HttpError(400, 'code y description son obligatorios');
@@ -571,6 +715,7 @@ router.post(
     const normalizedUnitsPerBox = normalizeUnitsPerBox(unitsPerBox, { fieldName: 'unitsPerBox' });
     const precioInput = Object.prototype.hasOwnProperty.call(payload, 'precio') ? precio : pDecimal;
     const normalizedPrecio = normalizePrecio(precioInput, { fieldName: 'precio' });
+    const normalizedPriceTiers = normalizePriceTiers(priceTiers, normalizedPrecio);
     let item;
     try {
       let itemData = {
@@ -587,6 +732,10 @@ router.post(
       }
       if (normalizedPrecio !== undefined) {
         itemData.pDecimal = normalizedPrecio;
+      }
+      if (normalizedPriceTiers !== undefined) {
+        itemData.priceTiers = normalizedPriceTiers;
+        itemData.pDecimal = normalizedPriceTiers[0]?.price ?? normalizedPrecio ?? null;
       }
       itemData = await assignSkuToNewItemData(itemData);
       item = await Item.create(itemData);
@@ -617,7 +766,7 @@ router.put(
     if (!Types.ObjectId.isValid(id)) {
       throw new HttpError(400, 'Artículo inválido');
     }
-    const item = await Item.findById(id);
+    const item = await Item.findOne({ _id: id, deletedAt: null });
     if (!item) {
       throw new HttpError(404, 'Artículo no encontrado');
     }
@@ -633,7 +782,8 @@ router.put(
       needsRecount,
       unitsPerBox,
       precio,
-      pDecimal
+      pDecimal,
+      priceTiers
     } = payload || {};
     if (typeof description === 'string' && description && description !== item.description) {
       item.description = description;
@@ -739,6 +889,16 @@ router.put(
         item.pDecimal = normalizedPrecio;
       }
     }
+    if (Object.prototype.hasOwnProperty.call(payload, 'priceTiers')) {
+      const fallbackPrice = item.pDecimal === null || item.pDecimal === undefined ? undefined : Number(item.pDecimal);
+      const normalizedPriceTiers = normalizePriceTiers(priceTiers, fallbackPrice) || [];
+      if (JSON.stringify(normalizedPriceTiers) !== JSON.stringify(item.priceTiers || [])) {
+        item.priceTiers = normalizedPriceTiers;
+        item.pDecimal = normalizedPriceTiers[0]?.price ?? null;
+      }
+    } else if (precioWasProvided && item.pDecimal !== null && item.pDecimal !== undefined) {
+      item.priceTiers = [{ minQuantity: 1, price: Number(item.pDecimal) }];
+    }
 
     const currentImages = Array.isArray(item.images) ? item.images : [];
     const existingPathSet = new Set(currentImages.map(sanitizeImagePath).filter(Boolean));
@@ -815,28 +975,24 @@ router.delete(
     if (!Types.ObjectId.isValid(id)) {
       throw new HttpError(400, 'Artículo inválido');
     }
-    const item = await Item.findById(id);
+    const item = await Item.findOne({ _id: id, deletedAt: null });
     if (!item) {
       throw new HttpError(404, 'Artículo no encontrado');
     }
 
     const auditSnapshot = await buildItemAuditSnapshot(item);
-    const imagesToRemove = Array.isArray(item.images)
-      ? item.images.map(sanitizeImagePath).filter(Boolean)
-      : [];
-
-    await item.deleteOne();
-
-    if (imagesToRemove.length > 0) {
-      await Promise.allSettled(imagesToRemove.map(removeFileSafe));
-    }
+    const deletedAt = new Date();
+    item.deletedAt = deletedAt;
+    item.deletedBy = req.user?.username || 'Desconocido';
+    item.scheduledDeletionAt = new Date(deletedAt.getTime() + TRASH_RETENTION_DAYS * 24 * 60 * 60 * 1000);
+    await item.save();
 
     await recordAuditEvent({
       action: 'Artículo',
-      request: buildItemAuditSummary('Eliminación de artículo', auditSnapshot),
+      request: buildItemAuditSummary('Artículo enviado a papelera', auditSnapshot),
       user: req.user?.username || 'Desconocido',
       details: {
-        summary: buildItemAuditSummary('Eliminación de artículo', auditSnapshot),
+        summary: buildItemAuditSummary('Artículo enviado a papelera', auditSnapshot),
         item: auditSnapshot
       }
     });

--- a/backend/src/routes/reports.js
+++ b/backend/src/routes/reports.js
@@ -64,7 +64,7 @@ router.get(
     const isRequestingUngrouped = requestedGroupId === 'ungrouped';
 
     const [items, groups, locations] = await Promise.all([
-      Item.find().populate('group'),
+      Item.find({ deletedAt: null }).populate('group'),
       Group.find(),
       Location.find()
     ]);
@@ -165,7 +165,7 @@ async function respondStockByLocation(req, res) {
   const requestedLocationId = typeof req.query.locationId === 'string' ? req.query.locationId : null;
 
   const [items, locations] = await Promise.all([
-    Item.find(),
+    Item.find({ deletedAt: null }),
     Location.find({ type: 'warehouse' })
   ]);
   const locationsById = new Map(

--- a/backend/src/routes/stock.js
+++ b/backend/src/routes/stock.js
@@ -241,7 +241,10 @@ async function resolveItemIdentifier(rawValue) {
   if (Types.ObjectId.isValid(trimmed)) {
     return trimmed;
   }
-  const item = await Item.findOne({ code: new RegExp(`^${escapeRegex(trimmed)}$`, 'i') })
+  const item = await Item.findOne({
+    code: new RegExp(`^${escapeRegex(trimmed)}$`, 'i'),
+    deletedAt: null
+  })
     .select('_id')
     .lean();
   return item ? item._id : null;
@@ -263,7 +266,7 @@ router.get(
       limit: rawLimit
     } = req.query || {};
 
-    const filter = {};
+    const filter = { deletedAt: null };
     const normalizedGroupId = typeof groupId === 'string' ? groupId.trim() : '';
     if (normalizedGroupId) {
       const groupIds = await collectGroupAndDescendantIds(normalizedGroupId);

--- a/backend/src/services/itemTrashService.js
+++ b/backend/src/services/itemTrashService.js
@@ -1,0 +1,51 @@
+const path = require('path');
+const fs = require('fs');
+const Item = require('../models/Item');
+const { recordAuditEvent } = require('./auditService');
+
+const { promises: fsPromises } = fs;
+const projectRoot = path.join(__dirname, '..', '..');
+
+function sanitizeItemImagePath(value) {
+  if (typeof value !== 'string') return null;
+  const normalized = path.posix.normalize(value.trim().replace(/^\/+/, ''));
+  return normalized.startsWith('uploads/items/') ? normalized : null;
+}
+
+async function removeImage(relativePath) {
+  const safePath = sanitizeItemImagePath(relativePath);
+  if (!safePath) return;
+  try {
+    await fsPromises.unlink(path.join(projectRoot, safePath));
+  } catch (error) {
+    if (error.code !== 'ENOENT') {
+      console.warn('No se pudo purgar una imagen de la papelera', { path: safePath, error });
+    }
+  }
+}
+
+async function permanentlyDeleteItem(item, { user = 'Sistema', automatic = false } = {}) {
+  const images = Array.isArray(item.images) ? item.images : [];
+  await Promise.allSettled(images.map(removeImage));
+  const summary = `${automatic ? 'Eliminación automática' : 'Eliminación definitiva'} de artículo: ${item.code} - ${item.description}`;
+  await item.deleteOne();
+  await recordAuditEvent({
+    action: 'Artículo',
+    request: summary,
+    user,
+    details: { summary, itemId: String(item._id), code: item.code, automatic }
+  });
+}
+
+async function purgeExpiredItems() {
+  const expired = await Item.find({
+    deletedAt: { $ne: null },
+    scheduledDeletionAt: { $ne: null, $lte: new Date() }
+  });
+  for (const item of expired) {
+    await permanentlyDeleteItem(item, { automatic: true });
+  }
+  return expired.length;
+}
+
+module.exports = { permanentlyDeleteItem, purgeExpiredItems };

--- a/backend/src/services/stockService.js
+++ b/backend/src/services/stockService.js
@@ -79,7 +79,7 @@ async function findItemOrThrow(itemId) {
   if (!mongoose.Types.ObjectId.isValid(itemId)) {
     throw new HttpError(404, 'Artículo no encontrado');
   }
-  const item = await Item.findById(itemId);
+  const item = await Item.findOne({ _id: itemId, deletedAt: null });
   if (!item) {
     throw new HttpError(404, 'Artículo no encontrado');
   }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -5,6 +5,7 @@ import LoginPage from './pages/Login.jsx';
 import DashboardPage from './pages/Dashboard.jsx';
 import ItemsPage from './pages/items/ItemsPage.jsx';
 import ItemsDownloadPage from './pages/items/ItemsDownloadPage.jsx';
+import ItemsTrashPage from './pages/items/ItemsTrashPage.jsx';
 import InventoryAlertsPage from './pages/InventoryAlerts.jsx';
 import GroupsPage from './pages/groups/GroupsPage.jsx';
 import MovementRequestsPage from './pages/movements/MovementRequestsPage.jsx';
@@ -30,6 +31,7 @@ export default function App() {
         <Route path="inventory/alerts" element={<InventoryAlertsPage />} />
         <Route path="items" element={<ItemsPage />} />
         <Route path="items/download" element={<ItemsDownloadPage />} />
+        <Route path="items/trash" element={<ItemsTrashPage />} />
         <Route path="groups" element={<GroupsPage />} />
         <Route path="requests" element={<MovementRequestsPage />} />
         <Route path="approvals" element={<ApprovalsPage />} />

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -4,6 +4,7 @@ import { useAuth } from '../context/AuthContext.jsx';
 const NAV_ITEMS = [
   { to: '/', label: 'Resumen' },
   { to: '/items', label: 'Artículos', permission: 'items.read', hiddenForRoles: ['Operador'] },
+  { to: '/items/trash', label: 'Papelera', permission: 'items.write', hiddenForRoles: ['Operador'] },
   { to: '/items/download', label: 'Descarga PDF', permission: 'items.read', hiddenForRoles: ['Operador', 'Supervisor'] },
   { to: '/groups', label: 'Grupos', permission: 'items.write', hiddenForRoles: ['Operador'] },
   { to: '/requests', label: 'Solicitudes', permission: 'stock.request' },

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -908,3 +908,54 @@ th {
     display: none;
   }
 }
+
+.price-tier-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.price-tier-row {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(150px, 1fr)) auto;
+  align-items: end;
+  gap: 0.75rem;
+  padding: 0.75rem;
+  border: 1px solid #bae6fd;
+  border-radius: 10px;
+  background: #f0f9ff;
+}
+
+.price-tier-row label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+@media (max-width: 640px) {
+  .price-tier-row { grid-template-columns: 1fr; }
+}
+
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1250;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  background: rgba(15, 23, 42, 0.72);
+}
+.modal-card {
+  width: min(760px, 100%);
+  max-height: 90vh;
+  overflow: auto;
+  padding: 1.25rem;
+  border-radius: 12px;
+  background: #fff;
+  box-shadow: 0 20px 60px rgba(15, 23, 42, 0.3);
+}
+.recount-location-list { display: flex; flex-direction: column; gap: 0.65rem; margin: 1rem 0; }
+.recount-location-row { display: grid; grid-template-columns: minmax(160px, 1fr) 120px 120px; gap: 0.75rem; align-items: end; padding: 0.75rem; border: 1px solid #dbeafe; border-radius: 8px; }
+.recount-location-row label { display: flex; flex-direction: column; gap: 0.3rem; }
+@media (max-width: 640px) { .recount-location-row { grid-template-columns: 1fr; } }

--- a/frontend/src/pages/InventoryAlerts.jsx
+++ b/frontend/src/pages/InventoryAlerts.jsx
@@ -57,6 +57,9 @@ const buildItemSummaries = items =>
       null,
     needsRecount: Boolean(item.needsRecount),
     updatedAt: item.updatedAt || null,
+    stock: item.stock || {},
+    lastCountedAt: item.lastCountedAt || null,
+    lastCountedBy: item.lastCountedBy || null,
     total: computeTotalStockFromMap(item.stock)
   }));
 
@@ -66,6 +69,7 @@ export default function InventoryAlertsPage() {
   const location = useLocation();
   const permissions = useMemo(() => user?.permissions || [], [user]);
   const canViewCatalog = permissions.includes('items.read');
+  const canWrite = permissions.includes('items.write');
 
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -73,6 +77,11 @@ export default function InventoryAlertsPage() {
   const [activeSection, setActiveSection] = useState('all');
   const [recountSearch, setRecountSearch] = useState('');
   const [outOfStockSearch, setOutOfStockSearch] = useState('');
+  const [locations, setLocations] = useState([]);
+  const [editingRecount, setEditingRecount] = useState(null);
+  const [recountStock, setRecountStock] = useState({});
+  const [savingRecount, setSavingRecount] = useState(false);
+  const [successMessage, setSuccessMessage] = useState('');
   const recountThresholdDays = RECOUNT_THRESHOLD_DAYS;
 
   useEffect(() => {
@@ -120,6 +129,10 @@ export default function InventoryAlertsPage() {
           pageNumber += 1;
         }
         setItemsSnapshot(collectedItems);
+        if (canWrite) {
+          const locationsResponse = await api.get('/locations');
+          setLocations(Array.isArray(locationsResponse) ? locationsResponse : locationsResponse?.items || []);
+        }
       } catch (err) {
         if (!active) {
           return;
@@ -135,7 +148,44 @@ export default function InventoryAlertsPage() {
     return () => {
       active = false;
     };
-  }, [api, canViewCatalog]);
+  }, [api, canViewCatalog, canWrite]);
+
+  const locationId = location => String(location?.id || location?._id || '');
+  const beginRecountEdit = item => {
+    const draft = {};
+    locations.forEach(location => {
+      const id = locationId(location);
+      const quantity = item.stock?.[id] || { boxes: 0, units: 0 };
+      draft[id] = { boxes: String(quantity.boxes || ''), units: String(quantity.units || '') };
+    });
+    setRecountStock(draft);
+    setEditingRecount(item);
+  };
+  const updateRecountStock = (id, field, value) => {
+    if (value !== '' && (!Number.isFinite(Number(value)) || Number(value) < 0)) return;
+    setRecountStock(prev => ({ ...prev, [id]: { ...prev[id], [field]: value } }));
+  };
+  const confirmRecount = async (item, stock = null) => {
+    setSavingRecount(true);
+    setError(null);
+    try {
+      const payload = stock ? {
+        stock: Object.fromEntries(Object.entries(stock).map(([id, quantity]) => [id, {
+          boxes: Number(quantity.boxes || 0), units: Number(quantity.units || 0)
+        }]))
+      } : {};
+      await api.patch(`/items/${item.id}/recount`, payload);
+      setItemsSnapshot(prev => prev.map(candidate => candidate.id === item.id
+        ? { ...candidate, needsRecount: false, ...(stock ? { stock: payload.stock } : {}) }
+        : candidate));
+      setEditingRecount(null);
+      setSuccessMessage(`Recuento de ${item.code} confirmado.`);
+    } catch (err) {
+      setError(err);
+    } finally {
+      setSavingRecount(false);
+    }
+  };
 
   useEffect(() => {
     if (loading) {
@@ -219,6 +269,30 @@ export default function InventoryAlertsPage() {
       </p>
 
       {error && <ErrorMessage error={error} />}
+      {successMessage && <div className="success-message">{successMessage}</div>}
+
+      {editingRecount && (
+        <div className="modal-overlay" role="dialog" aria-modal="true">
+          <div className="modal-card">
+            <h3>Editar cantidad · {editingRecount.code}</h3>
+            <p>{editingRecount.description}</p>
+            <div className="recount-location-list">
+              {locations.map(location => {
+                const id = locationId(location);
+                return <div className="recount-location-row" key={id}>
+                  <strong>{location.name}</strong>
+                  <label>Cajas<input type="number" min="0" value={recountStock[id]?.boxes ?? ''} onChange={event => updateRecountStock(id, 'boxes', event.target.value)} /></label>
+                  <label>Unidades<input type="number" min="0" value={recountStock[id]?.units ?? ''} onChange={event => updateRecountStock(id, 'units', event.target.value)} /></label>
+                </div>;
+              })}
+            </div>
+            <div className="inline-actions" style={{ justifyContent: 'flex-end' }}>
+              <button type="button" className="secondary-button" onClick={() => setEditingRecount(null)}>Cancelar</button>
+              <button type="button" onClick={() => confirmRecount(editingRecount, recountStock)} disabled={savingRecount}>{savingRecount ? 'Guardando…' : 'Guardar y marcar OK'}</button>
+            </div>
+          </div>
+        </div>
+      )}
 
       {loading ? (
         <LoadingIndicator message="Cargando alertas de inventario..." />
@@ -283,6 +357,7 @@ export default function InventoryAlertsPage() {
                             <th>Stock</th>
                             <th>Motivo</th>
                             <th>Última actualización</th>
+                            {canWrite && <th>Acciones</th>}
                           </tr>
                         </thead>
                         <tbody>
@@ -294,6 +369,10 @@ export default function InventoryAlertsPage() {
                               <td>{formatQuantity(item.total)}</td>
                               <td>{formatRecountReasons(item)}</td>
                               <td>{formatUpdatedAt(item.updatedAt)}</td>
+                              {canWrite && <td><div className="inline-actions">
+                                <button type="button" className="secondary-button" onClick={() => beginRecountEdit(item)}>Editar cantidad</button>
+                                <button type="button" onClick={() => confirmRecount(item)} disabled={savingRecount}>Recontado OK</button>
+                              </div></td>}
                             </tr>
                           ))}
                         </tbody>

--- a/frontend/src/pages/items/ItemsPage.jsx
+++ b/frontend/src/pages/items/ItemsPage.jsx
@@ -191,6 +191,7 @@ export default function ItemsPage() {
     needsRecount: false,
     unitsPerBox: '',
     precio: '',
+    priceTiers: [{ minQuantity: '1', price: '' }],
     gender: '',
     size: '',
     color: '',
@@ -207,6 +208,7 @@ export default function ItemsPage() {
   const [previewImages, setPreviewImages] = useState([]);
   const [previewIndex, setPreviewIndex] = useState(null);
   const [editingItem, setEditingItem] = useState(null);
+  const [markingAllRecount, setMarkingAllRecount] = useState(false);
 
   const updateAttributeOptionsFromItems = useCallback(itemsList => {
     const sizeValues = extractAttributeValues(itemsList, 'size');
@@ -442,6 +444,7 @@ export default function ItemsPage() {
       needsRecount: false,
       unitsPerBox: '',
       precio: '',
+      priceTiers: [{ minQuantity: '1', price: '' }],
       gender: '',
       size: '',
       color: '',
@@ -493,6 +496,23 @@ export default function ItemsPage() {
         }
       };
     });
+  };
+
+  const handlePriceTierChange = (index, field, value) => {
+    setFormValues(prev => ({
+      ...prev,
+      priceTiers: prev.priceTiers.map((tier, tierIndex) =>
+        tierIndex === index ? { ...tier, [field]: value } : tier
+      )
+    }));
+  };
+
+  const addPriceTier = () => {
+    setFormValues(prev => ({ ...prev, priceTiers: [...prev.priceTiers, { minQuantity: '', price: '' }] }));
+  };
+
+  const removePriceTier = index => {
+    setFormValues(prev => ({ ...prev, priceTiers: prev.priceTiers.filter((_, tierIndex) => tierIndex !== index) }));
   };
 
   const buildPayload = () => {
@@ -555,14 +575,11 @@ export default function ItemsPage() {
       stock,
       images: [...existingImages, ...imageFiles.map(image => image.dataUrl)].filter(Boolean)
     };
-    const precioValue = typeof formValues.precio === 'string' ? formValues.precio.trim() : '';
-    if (precioValue) {
-      payload.precio = precioValue;
-      payload.pDecimal = precioValue;
-    } else if (editingItem) {
-      payload.precio = null;
-      payload.pDecimal = null;
-    }
+    payload.priceTiers = (formValues.priceTiers || [])
+      .filter(tier => tier.minQuantity !== '' && tier.price !== '')
+      .map(tier => ({ minQuantity: Number(tier.minQuantity), price: Number(tier.price) }));
+    payload.precio = payload.priceTiers[0]?.price ?? null;
+    payload.pDecimal = payload.precio;
     return payload;
   };
 
@@ -670,6 +687,17 @@ export default function ItemsPage() {
     setPreviewIndex(targetIndex);
   };
 
+  const handleItemImagesOpen = item => {
+    const gallery = (Array.isArray(item?.images) ? item.images : []).map((image, index) => ({
+      src: getImageUrl(image),
+      alt: `${item.code} · imagen ${index + 1}`,
+      key: image
+    }));
+    if (gallery.length === 0) return;
+    setPreviewImages(gallery);
+    setPreviewIndex(0);
+  };
+
   const handlePreviewClose = () => {
     setPreviewImages([]);
     setPreviewIndex(null);
@@ -755,7 +783,10 @@ export default function ItemsPage() {
         ? item.precio
         : item.pDecimal !== null && item.pDecimal !== undefined
           ? item.pDecimal
-          : null;
+        : null;
+    const priceTiers = Array.isArray(item.priceTiers) && item.priceTiers.length > 0
+      ? item.priceTiers.map(tier => ({ minQuantity: String(tier.minQuantity), price: String(tier.price) }))
+      : [{ minQuantity: '1', price: precioBase === null ? '' : String(precioBase) }];
 
     setFormValues({
       code: item.code,
@@ -765,6 +796,7 @@ export default function ItemsPage() {
       unitsPerBox:
         item.unitsPerBox === null || item.unitsPerBox === undefined ? '' : String(item.unitsPerBox),
       precio: precioBase === null ? '' : Number(precioBase).toFixed(2),
+      priceTiers,
       gender: item.attributes?.gender || '',
       size: item.attributes?.size || '',
       color: item.attributes?.color || '',
@@ -777,7 +809,7 @@ export default function ItemsPage() {
   const handleDelete = async item => {
     if (!item) return;
     const confirmed = window.confirm(
-      `¿Seguro que deseas eliminar el artículo ${item.code}? Esta acción no se puede deshacer.`
+      `¿Enviar el artículo ${item.code} a la papelera? Podrá restaurarse durante 30 días.`
     );
     if (!confirmed) {
       return;
@@ -794,7 +826,7 @@ export default function ItemsPage() {
         resetForm();
       }
 
-      setSuccessMessage(`Artículo ${item.code} eliminado correctamente.`);
+      setSuccessMessage(`Artículo ${item.code} enviado a la papelera.`);
 
       let nextPage = page;
       let response = await api.get('/items', {
@@ -824,6 +856,26 @@ export default function ItemsPage() {
     }
   };
 
+  const handleMarkAllForRecount = async () => {
+    const confirmed = window.confirm(
+      `Se marcarán los ${total} artículos activos para reconteo pendiente. ¿Desea continuar?`
+    );
+    if (!confirmed) return;
+    setMarkingAllRecount(true);
+    setError(null);
+    try {
+      const response = await api.post('/items/recount/mark-all', {});
+      setItems(prev => prev.map(item => ({ ...item, needsRecount: true })));
+      setSuccessMessage(
+        `Reconteo total iniciado: ${response.changed} artículo(s) marcados; ${response.alreadyPending} ya estaban pendientes.`
+      );
+    } catch (err) {
+      setError(err);
+    } finally {
+      setMarkingAllRecount(false);
+    }
+  };
+
   return (
     <div>
       <div className="flex-between">
@@ -833,8 +885,13 @@ export default function ItemsPage() {
             Administre la taxonomía, atributos y stock distribuido por ubicación para cada artículo.
           </p>
         </div>
-        <div>
+        <div className="inline-actions">
           <span className="badge">Total: {total}</span>
+          {canWrite && (
+            <button type="button" onClick={handleMarkAllForRecount} disabled={markingAllRecount || total === 0}>
+              {markingAllRecount ? 'Marcando…' : 'Marcar todos para reconteo'}
+            </button>
+          )}
         </div>
       </div>
 
@@ -925,18 +982,53 @@ export default function ItemsPage() {
                   })}
                 </select>
               </div>
-              <div className="input-group">
-                <label htmlFor="precio">Precio</label>
-                <input
-                  id="precio"
-                  name="precio"
-                  type="number"
-                  min="0"
-                  step="0.01"
-                  value={formValues.precio}
-                  onChange={handleFormChange}
-                  placeholder="Precio unitario"
-                />
+              <div className="input-group" style={{ gridColumn: '1 / -1' }}>
+                <div className="flex-between">
+                  <div>
+                    <label>Precios por cantidad</label>
+                    <p className="input-helper">Cada precio se aplica desde la cantidad indicada.</p>
+                  </div>
+                  <button type="button" className="secondary-button" onClick={addPriceTier}>Agregar precio</button>
+                </div>
+                <div className="price-tier-editor">
+                  {(formValues.priceTiers || []).map((tier, index) => (
+                    <div className="price-tier-row" key={`${index}-${tier.minQuantity}`}>
+                      <label>
+                        Desde
+                        <input
+                          type="number"
+                          min="1"
+                          step="1"
+                          value={tier.minQuantity}
+                          onChange={event => handlePriceTierChange(index, 'minQuantity', event.target.value)}
+                          disabled={index === 0}
+                          required
+                        />
+                      </label>
+                      <label>
+                        Precio unitario
+                        <input
+                          type="number"
+                          min="0"
+                          step="0.01"
+                          value={tier.price}
+                          onChange={event => handlePriceTierChange(index, 'price', event.target.value)}
+                          required
+                        />
+                      </label>
+                      {index > 0 && (
+                        <button type="button" className="danger-button" onClick={() => removePriceTier(index)}>
+                          Quitar
+                        </button>
+                      )}
+                    </div>
+                  ))}
+                </div>
+                <div className="chip-list">
+                  {(formValues.priceTiers || []).filter(tier => tier.minQuantity && tier.price !== '').map((tier, index) => (
+                    <span className="badge" key={`preview-${index}`}>x{tier.minQuantity} · ${Number(tier.price).toLocaleString('es-AR')}</span>
+                  ))}
+                </div>
               </div>
               <div className="input-group">
                 <label htmlFor="needsRecount">Recuento manual</label>
@@ -1283,12 +1375,17 @@ export default function ItemsPage() {
                       <td>{item.description}</td>
                       <td>{item.group?.name || 'Sin grupo'}</td>
                       <td>
-                        {precioBase === null
-                          ? '-'
-                          : Number(precioBase).toLocaleString('es-AR', {
-                              minimumFractionDigits: 2,
-                              maximumFractionDigits: 2
-                            })}
+                        <div className="chip-list">
+                          {(Array.isArray(item.priceTiers) && item.priceTiers.length > 0
+                            ? item.priceTiers
+                            : precioBase === null ? [] : [{ minQuantity: 1, price: precioBase }]
+                          ).map(tier => (
+                            <span className="badge" key={tier.minQuantity}>
+                              x{tier.minQuantity} · ${Number(tier.price).toLocaleString('es-AR', { minimumFractionDigits: 2 })}
+                            </span>
+                          ))}
+                          {precioBase === null && (!item.priceTiers || item.priceTiers.length === 0) && <span>-</span>}
+                        </div>
                       </td>
                       <td>
                         <div className="chip-list">
@@ -1301,7 +1398,13 @@ export default function ItemsPage() {
                         </div>
                       </td>
                       <td>{item.unitsPerBox === null || item.unitsPerBox === undefined ? '-' : item.unitsPerBox}</td>
-                      <td>{Array.isArray(item.images) ? item.images.length : 0}</td>
+                      <td>
+                        {Array.isArray(item.images) && item.images.length > 0 ? (
+                          <button type="button" className="secondary-button" onClick={() => handleItemImagesOpen(item)}>
+                            Ver imágenes ({item.images.length})
+                          </button>
+                        ) : '-'}
+                      </td>
                       <td>
                       <div className="chip-list">
                         {(() => {

--- a/frontend/src/pages/items/ItemsTrashPage.jsx
+++ b/frontend/src/pages/items/ItemsTrashPage.jsx
@@ -1,0 +1,100 @@
+import { useCallback, useEffect, useState } from 'react';
+import useApi from '../../hooks/useApi.js';
+import LoadingIndicator from '../../components/LoadingIndicator.jsx';
+import ErrorMessage from '../../components/ErrorMessage.jsx';
+
+const formatDateTime = value => value
+  ? new Intl.DateTimeFormat('es-AR', {
+      dateStyle: 'short', timeStyle: 'short', hour12: false
+    }).format(new Date(value))
+  : '-';
+
+export default function ItemsTrashPage() {
+  const api = useApi();
+  const [items, setItems] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [workingId, setWorkingId] = useState(null);
+  const [error, setError] = useState(null);
+  const [message, setMessage] = useState('');
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await api.get('/items/trash');
+      setItems(Array.isArray(response?.items) ? response.items : []);
+    } catch (err) {
+      setError(err);
+    } finally {
+      setLoading(false);
+    }
+  }, [api]);
+
+  useEffect(() => { load(); }, [load]);
+
+  const restore = async item => {
+    if (!window.confirm(`¿Restaurar el artículo ${item.code}?`)) return;
+    setWorkingId(item.id);
+    try {
+      await api.post(`/items/trash/${item.id}/restore`, {});
+      setItems(prev => prev.filter(candidate => candidate.id !== item.id));
+      setMessage(`Artículo ${item.code} restaurado.`);
+    } catch (err) {
+      setError(err);
+    } finally {
+      setWorkingId(null);
+    }
+  };
+
+  const removePermanently = async item => {
+    if (!window.confirm(`¿Eliminar definitivamente ${item.code}? Esta acción no se puede deshacer.`)) return;
+    setWorkingId(item.id);
+    try {
+      await api.delete(`/items/trash/${item.id}`);
+      setItems(prev => prev.filter(candidate => candidate.id !== item.id));
+      setMessage(`Artículo ${item.code} eliminado definitivamente.`);
+    } catch (err) {
+      setError(err);
+    } finally {
+      setWorkingId(null);
+    }
+  };
+
+  return (
+    <div>
+      <div className="flex-between">
+        <div>
+          <h2>Papelera de artículos</h2>
+          <p style={{ color: '#475569', marginTop: '-0.4rem' }}>
+            Los artículos se eliminan definitivamente 30 días después de enviarlos a la papelera.
+          </p>
+        </div>
+        <span className="badge">Total: {items.length}</span>
+      </div>
+      {error && <ErrorMessage error={error} />}
+      {message && <div className="success-message">{message}</div>}
+      {loading ? <LoadingIndicator message="Cargando papelera..." /> : (
+        <div className="section-card">
+          <div className="table-wrapper">
+            <table>
+              <thead><tr><th>Código</th><th>Descripción</th><th>Eliminado por</th><th>Fecha</th><th>Eliminación definitiva</th><th>Acciones</th></tr></thead>
+              <tbody>
+                {items.map(item => (
+                  <tr key={item.id}>
+                    <td>{item.code}</td><td>{item.description}</td><td>{item.deletedBy || '-'}</td>
+                    <td>{formatDateTime(item.deletedAt)}</td><td>{formatDateTime(item.scheduledDeletionAt)}</td>
+                    <td><div className="inline-actions">
+                      <button type="button" onClick={() => restore(item)} disabled={workingId === item.id}>Restaurar</button>
+                      <button type="button" className="danger-button" onClick={() => removePermanently(item)} disabled={workingId === item.id}>Eliminar definitivamente</button>
+                    </div></td>
+                  </tr>
+                ))}
+                {items.length === 0 && <tr><td colSpan="6" style={{ textAlign: 'center' }}>La papelera está vacía.</td></tr>}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/movements/ApprovalsPage.jsx
+++ b/frontend/src/pages/movements/ApprovalsPage.jsx
@@ -5,6 +5,7 @@ import LoadingIndicator from '../../components/LoadingIndicator.jsx';
 import ErrorMessage from '../../components/ErrorMessage.jsx';
 import { formatQuantity } from '../../utils/quantity.js';
 import StockStatusBadge from '../../components/StockStatusBadge.jsx';
+import { formatDateTime24 } from '../../utils/dateTime.js';
 import { aggregatePendingByItem, computeTotalStockFromMap, deriveStockStatus } from '../../utils/stockStatus.js';
 import { MOVEMENT_TYPE_BADGE_CLASS, MOVEMENT_TYPE_LABELS, resolveMovementType } from '../../utils/movements.js';
 
@@ -188,7 +189,7 @@ export default function ApprovalsPage() {
                         )}
                       </td>
                       <td>{request.requestedBy?.username || 'N/D'}</td>
-                      <td>{new Date(request.requestedAt).toLocaleString('es-AR')}</td>
+                      <td>{formatDateTime24(request.requestedAt)}</td>
                       <td>
                         <div className="inline-actions">
                           <button type="button" onClick={() => handleApprove(request.id)}>

--- a/frontend/src/pages/movements/MovementRequestsPage.jsx
+++ b/frontend/src/pages/movements/MovementRequestsPage.jsx
@@ -5,6 +5,7 @@ import LoadingIndicator from '../../components/LoadingIndicator.jsx';
 import ErrorMessage from '../../components/ErrorMessage.jsx';
 import { ensureQuantity, formatQuantity } from '../../utils/quantity.js';
 import StockStatusBadge from '../../components/StockStatusBadge.jsx';
+import { formatDateTime24 } from '../../utils/dateTime.js';
 import { aggregatePendingByItem, computeTotalStockFromMap, deriveStockStatus } from '../../utils/stockStatus.js';
 import {
   MOVEMENT_TYPE_BADGE_CLASS,
@@ -852,7 +853,7 @@ export default function MovementRequestsPage() {
                           )}
                         </div>
                       </td>
-                      <td>{new Date(request.requestedAt).toLocaleString('es-AR')}</td>
+                      <td>{formatDateTime24(request.requestedAt)}</td>
                       <td>
                         {request.status === 'rejected' && (
                           <button

--- a/frontend/src/utils/dateTime.js
+++ b/frontend/src/utils/dateTime.js
@@ -1,0 +1,15 @@
+export function formatDateTime24(value, options = {}) {
+  if (!value) return '-';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return '-';
+  return new Intl.DateTimeFormat('es-AR', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+    ...options
+  }).format(date);
+}

--- a/frontend/src/utils/inventoryAlerts.js
+++ b/frontend/src/utils/inventoryAlerts.js
@@ -24,6 +24,9 @@ const normalizeItem = (item, totalQuantity) => ({
     null,
   needsRecount: Boolean(item?.needsRecount),
   updatedAt: item?.updatedAt || null,
+  stock: item?.stock || {},
+  lastCountedAt: item?.lastCountedAt || null,
+  lastCountedBy: item?.lastCountedBy || null,
   total: totalQuantity
 });
 


### PR DESCRIPTION
### Motivation
- Introduce a recoverable trash for items so deletions can be undone and permanently removed after a retention period.
- Support tiered pricing per item and surface price tiers in the UI to handle quantity-based pricing.
- Provide bulk and per-item recount workflows to mark items for recount and confirm counts from the inventory alerts UI.
- Ensure expired trashed items are cleaned up automatically to remove images and DB records.

### Description
- Extended the `Item` model with `priceTiers`, `lastCountedAt`, `lastCountedBy`, `deletedAt`, `deletedBy`, and `scheduledDeletionAt` fields and added a `priceTier` sub-schema.
- Implemented a new `itemTrashService` with `permanentlyDeleteItem` and `purgeExpiredItems`, and wired an hourly purge timer in `backend/src/index.js` that runs `purgeExpiredItems()`.
- Converted item deletes to soft-delete by setting `deletedAt`, `deletedBy` and `scheduledDeletionAt` (default retention `TRASH_RETENTION_DAYS = 30`) and added routes to list trash (`GET /items/trash`), restore (`POST /items/trash/:id/restore`) and permanently remove (`DELETE /items/trash/:id`).
- Updated all item-finding queries in routes and services to ignore trashed items (added `{ deletedAt: null }` filters) and added endpoints to mark all items for recount (`POST /items/recount/mark-all`) and confirm an item's recount (`PATCH /items/:id/recount`).
- Added frontend changes: new `ItemsTrashPage`, sidebar link, trash UI with restore and permanent delete actions, price-tiers editor/display in `ItemsPage`, mark-all-for-recount button and per-item recount modal in `InventoryAlertsPage`, image lightbox improvements, CSS for new UI components, and a `formatDateTime24` util.

### Testing
- Ran the project's automated test suite with `npm test` and lint checks with `npm run lint`, and they completed successfully.
- Performed a local server start and exercised CRUD, trash/restore, permanent delete, price tiers creation/display, and recount flows as a smoke integration check, and all exercised behaviors worked as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a286a2441c4832aab9c176d03c169ae)