### PR TITLE
Add barcode reception: backend endpoint and frontend UI

### DIFF
--- a/backend/src/routes/stock.js
+++ b/backend/src/routes/stock.js
@@ -14,6 +14,7 @@ const {
   executeMovement,
   addMovementLog,
   findItemOrThrow,
+  ensureLocationExists,
   normalizeStoredQuantity
 } = require('../services/stockService');
 const { recordAuditEvent } = require('../services/auditService');
@@ -469,6 +470,79 @@ router.post(
       details: buildMovementAuditDetails(populated, 'Rechazo de solicitud', { rejectionReason: request.rejectedReason })
     });
     res.json(serializeMovementRequest(populated));
+  })
+);
+
+
+router.post(
+  '/barcode-reception',
+  requirePermission('stock.approve'),
+  asyncHandler(async (req, res) => {
+    const body = req.body || {};
+    const lines = Array.isArray(body.lines) ? body.lines : [];
+    if (lines.length === 0) {
+      throw new HttpError(400, 'Debe indicar al menos un artículo recibido');
+    }
+    if (lines.length > 200) {
+      throw new HttpError(400, 'La recepción no puede superar 200 artículos por confirmación');
+    }
+
+    const fromLocationId = body.fromLocation || body.fromDeposit;
+    const toLocationId = body.toLocation || body.toDeposit;
+    const [fromLocation, toLocation] = await Promise.all([
+      ensureLocationExists(fromLocationId, {
+        allowedTypes: ['externalOrigin'],
+        invalidTypeMessage: 'El origen debe ser una ubicación de tipo origen externo'
+      }),
+      ensureLocationExists(toLocationId, {
+        allowedTypes: ['warehouse'],
+        invalidTypeMessage: 'El destino debe ser un depósito interno'
+      })
+    ]);
+
+    const created = [];
+    for (const [index, line] of lines.entries()) {
+      const item = await findItemOrThrow(line.itemId);
+      const quantity = normalizeQuantityInput(line.quantity, { fieldName: `Cantidad del renglón ${index + 1}` });
+      const movementRequest = new MovementRequest({
+        item: item.id,
+        type: 'ingress',
+        fromLocation: fromLocation.id,
+        toLocation: toLocation.id,
+        quantity,
+        reason: body.reason || 'Recepción por códigos de barra',
+        requestedBy: req.user.id,
+        requestedAt: new Date(),
+        status: 'approved',
+        approvedBy: req.user.id,
+        approvedAt: new Date()
+      });
+      await movementRequest.save();
+      await addMovementLog(movementRequest.id, 'requested', req.user.id, requestMetadata(req));
+      await addMovementLog(movementRequest.id, 'approved', req.user.id, requestMetadata(req));
+      await executeMovement(movementRequest, req.user.id, requestMetadata(req));
+      const populated = await movementRequest.populate([
+        'item',
+        { path: 'requestedBy', populate: 'role' },
+        { path: 'approvedBy', populate: 'role' },
+        'fromLocation',
+        'toLocation'
+      ]);
+      created.push(populated);
+    }
+
+    await recordAuditEvent({
+      action: 'Recepción por código de barras',
+      request: `Recepción confirmada: ${created.length} artículo(s) | Origen: ${fromLocation.name} | Destino: ${toLocation.name}`,
+      user: req.user?.username || 'Desconocido',
+      details: {
+        fromLocation: serializeLocationSummary(fromLocation),
+        toLocation: serializeLocationSummary(toLocation),
+        lines: created.map(request => serializeMovementRequest(request))
+      }
+    });
+
+    res.status(201).json({ lines: created.map(serializeMovementRequest) });
   })
 );
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -7,6 +7,7 @@ import ItemsPage from './pages/items/ItemsPage.jsx';
 import ItemsDownloadPage from './pages/items/ItemsDownloadPage.jsx';
 import ItemsTrashPage from './pages/items/ItemsTrashPage.jsx';
 import OverstockPage from './pages/items/OverstockPage.jsx';
+import BarcodeReceptionPage from './pages/items/BarcodeReceptionPage.jsx';
 import InventoryAlertsPage from './pages/InventoryAlerts.jsx';
 import GroupsPage from './pages/groups/GroupsPage.jsx';
 import MovementRequestsPage from './pages/movements/MovementRequestsPage.jsx';
@@ -32,6 +33,7 @@ export default function App() {
         <Route path="inventory/alerts" element={<InventoryAlertsPage />} />
         <Route path="items" element={<ItemsPage />} />
         <Route path="overstock" element={<OverstockPage />} />
+        <Route path="items/barcode-reception" element={<BarcodeReceptionPage />} />
         <Route path="items/download" element={<ItemsDownloadPage />} />
         <Route path="items/trash" element={<ItemsTrashPage />} />
         <Route path="groups" element={<GroupsPage />} />

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -4,6 +4,7 @@ import { useAuth } from '../context/AuthContext.jsx';
 const NAV_ITEMS = [
   { to: '/', label: 'Resumen' },
   { to: '/items', label: 'Artículos', permission: 'items.read', hiddenForRoles: ['Operador'] },
+  { to: '/items/barcode-reception', label: 'Recepción por código', permission: 'stock.approve', hiddenForRoles: ['Operador'] },
   { to: '/overstock', label: 'Sobrestock', permission: 'items.read', hiddenForRoles: ['Operador'] },
   { to: '/items/trash', label: 'Papelera', permission: 'items.write', hiddenForRoles: ['Operador'] },
   { to: '/items/download', label: 'Descarga PDF', permission: 'items.read', hiddenForRoles: ['Operador', 'Supervisor'] },

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -967,3 +967,29 @@ th {
   gap: 0.4rem;
   min-width: 110px;
 }
+
+.barcode-reception-page {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.barcode-scan-card {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  border-color: #93c5fd;
+  background: linear-gradient(180deg, #eff6ff 0%, #fff 72%);
+}
+
+.barcode-scan-input input {
+  font-size: 1.35rem;
+  padding: 0.85rem 1rem;
+  letter-spacing: 0.06em;
+}
+
+.barcode-scan-message {
+  margin: 0;
+  color: #1e3a8a;
+  font-weight: 600;
+}

--- a/frontend/src/pages/items/BarcodeReceptionPage.jsx
+++ b/frontend/src/pages/items/BarcodeReceptionPage.jsx
@@ -1,0 +1,387 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import useApi from '../../hooks/useApi.js';
+import { useAuth } from '../../context/AuthContext.jsx';
+import LoadingIndicator from '../../components/LoadingIndicator.jsx';
+import ErrorMessage from '../../components/ErrorMessage.jsx';
+
+const SCAN_MODE_OPTIONS = [
+  { value: 'boxes', label: 'Cajas' },
+  { value: 'units', label: 'Unidades' }
+];
+
+function normalizeLocation(location) {
+  const rawId = location?.id || location?._id;
+  return {
+    id: rawId && typeof rawId === 'object' && typeof rawId.toString === 'function' ? rawId.toString() : rawId || '',
+    name: location?.name || '',
+    type: location?.type || 'warehouse',
+    status: location?.status || 'active'
+  };
+}
+
+function normalizeItem(item) {
+  return {
+    id: item?.id || item?._id || '',
+    code: item?.code || '',
+    description: item?.description || '',
+    stock: item?.stock || {}
+  };
+}
+
+function quantityLabel(quantity = {}) {
+  const boxes = Number(quantity.boxes) || 0;
+  const units = Number(quantity.units) || 0;
+  const parts = [];
+  if (boxes > 0) parts.push(`${boxes} caja${boxes === 1 ? '' : 's'}`);
+  if (units > 0) parts.push(`${units} unidad${units === 1 ? '' : 'es'}`);
+  return parts.length > 0 ? parts.join(' y ') : 'Sin cantidad';
+}
+
+export default function BarcodeReceptionPage() {
+  const api = useApi();
+  const { user } = useAuth();
+  const permissions = useMemo(() => user?.permissions || [], [user]);
+  const canReceive = permissions.includes('stock.approve');
+
+  const scannerRef = useRef(null);
+  const [loading, setLoading] = useState(true);
+  const [locations, setLocations] = useState([]);
+  const [originLocationId, setOriginLocationId] = useState('');
+  const [destinationLocationId, setDestinationLocationId] = useState('');
+  const [scanMode, setScanMode] = useState('boxes');
+  const [scanValue, setScanValue] = useState('');
+  const [lines, setLines] = useState([]);
+  const [error, setError] = useState(null);
+  const [successMessage, setSuccessMessage] = useState('');
+  const [scanMessage, setScanMessage] = useState('');
+  const [scanning, setScanning] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  const activeOrigins = useMemo(
+    () => locations.filter(location => location.type === 'externalOrigin' && location.status !== 'inactive'),
+    [locations]
+  );
+  const activeWarehouses = useMemo(
+    () => locations.filter(location => location.type === 'warehouse' && location.status !== 'inactive'),
+    [locations]
+  );
+
+  const focusScanner = useCallback(() => {
+    window.setTimeout(() => scannerRef.current?.focus(), 0);
+  }, []);
+
+  useEffect(() => {
+    let active = true;
+    const loadLocations = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const response = await api.get('/locations');
+        if (!active) return;
+        const normalized = Array.isArray(response)
+          ? response.map(normalizeLocation).sort((a, b) => a.name.localeCompare(b.name, 'es', { sensitivity: 'base' }))
+          : [];
+        setLocations(normalized);
+        const firstOrigin = normalized.find(location => location.type === 'externalOrigin' && location.status !== 'inactive');
+        const firstWarehouse = normalized.find(location => location.type === 'warehouse' && location.status !== 'inactive');
+        setOriginLocationId(firstOrigin?.id || '');
+        setDestinationLocationId(firstWarehouse?.id || '');
+      } catch (err) {
+        if (active) setError(err);
+      } finally {
+        if (active) setLoading(false);
+      }
+    };
+    loadLocations();
+    return () => {
+      active = false;
+    };
+  }, [api]);
+
+  useEffect(() => {
+    if (!loading) {
+      focusScanner();
+    }
+  }, [focusScanner, loading]);
+
+  const addScannedItem = useCallback(
+    item => {
+      const normalizedItem = normalizeItem(item);
+      const quantityIncrement = scanMode === 'boxes' ? { boxes: 1, units: 0 } : { boxes: 0, units: 1 };
+      setLines(prev => {
+        const existingIndex = prev.findIndex(line => line.itemId === normalizedItem.id);
+        if (existingIndex === -1) {
+          return [
+            {
+              itemId: normalizedItem.id,
+              code: normalizedItem.code,
+              description: normalizedItem.description,
+              quantity: quantityIncrement,
+              scans: 1
+            },
+            ...prev
+          ];
+        }
+        return prev.map((line, index) =>
+          index === existingIndex
+            ? {
+                ...line,
+                quantity: {
+                  boxes: (Number(line.quantity.boxes) || 0) + quantityIncrement.boxes,
+                  units: (Number(line.quantity.units) || 0) + quantityIncrement.units
+                },
+                scans: (Number(line.scans) || 0) + 1
+              }
+            : line
+        );
+      });
+      setSuccessMessage('');
+      setScanMessage(`${normalizedItem.code} agregado: +1 ${scanMode === 'boxes' ? 'caja' : 'unidad'}.`);
+    },
+    [scanMode]
+  );
+
+  const handleScan = useCallback(async () => {
+    const normalizedCode = scanValue.trim();
+    if (!normalizedCode || scanning) {
+      return;
+    }
+    setScanning(true);
+    setError(null);
+    setScanMessage('');
+    try {
+      const response = await api.get('/stock/items', { query: { search: normalizedCode, limit: 10 } });
+      const matches = Array.isArray(response) ? response : [];
+      const exactMatch = matches.find(item => item.code?.trim().toLowerCase() === normalizedCode.toLowerCase());
+      if (!exactMatch) {
+        setScanMessage(`No se encontró un artículo activo con el código ${normalizedCode}.`);
+        return;
+      }
+      addScannedItem(exactMatch);
+      setScanValue('');
+    } catch (err) {
+      setError(err);
+    } finally {
+      setScanning(false);
+      focusScanner();
+    }
+  }, [addScannedItem, api, focusScanner, scanValue, scanning]);
+
+  const handleScannerKeyDown = event => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      handleScan();
+    }
+  };
+
+  const handleQuantityChange = (itemId, field, value) => {
+    if (value !== '') {
+      const numeric = Number(value);
+      if (!Number.isFinite(numeric) || numeric < 0) return;
+    }
+    setLines(prev =>
+      prev.map(line =>
+        line.itemId === itemId
+          ? { ...line, quantity: { ...line.quantity, [field]: value === '' ? '' : Math.trunc(Number(value)) } }
+          : line
+      )
+    );
+  };
+
+  const handleRemoveLine = itemId => {
+    setLines(prev => prev.filter(line => line.itemId !== itemId));
+    focusScanner();
+  };
+
+  const totalScans = useMemo(() => lines.reduce((sum, line) => sum + (Number(line.scans) || 0), 0), [lines]);
+
+  const handleConfirm = async () => {
+    if (!canReceive || saving) return;
+    if (!originLocationId || !destinationLocationId) {
+      setError(new Error('Seleccioná un origen externo y un depósito destino.'));
+      return;
+    }
+    const payloadLines = lines
+      .map(line => ({
+        itemId: line.itemId,
+        quantity: {
+          boxes: Number(line.quantity.boxes) || 0,
+          units: Number(line.quantity.units) || 0
+        }
+      }))
+      .filter(line => line.quantity.boxes > 0 || line.quantity.units > 0);
+    if (payloadLines.length === 0) {
+      setError(new Error('Escaneá al menos un artículo con cantidad mayor a cero.'));
+      return;
+    }
+    setSaving(true);
+    setError(null);
+    setSuccessMessage('');
+    try {
+      const response = await api.post('/stock/barcode-reception', {
+        fromLocation: originLocationId,
+        toLocation: destinationLocationId,
+        lines: payloadLines
+      });
+      setSuccessMessage(`Recepción confirmada: ${response.lines?.length || payloadLines.length} artículo(s) ingresados.`);
+      setLines([]);
+      setScanValue('');
+      setScanMessage('Listo para escanear la próxima recepción.');
+    } catch (err) {
+      setError(err);
+    } finally {
+      setSaving(false);
+      focusScanner();
+    }
+  };
+
+  if (loading) {
+    return <LoadingIndicator message="Cargando recepción por códigos…" />;
+  }
+
+  if (!canReceive) {
+    return (
+      <div className="section-card">
+        <h2>Recepción por códigos de barra</h2>
+        <ErrorMessage error="Necesitás permiso de aprobación de stock para confirmar recepciones." />
+      </div>
+    );
+  }
+
+  return (
+    <div className="barcode-reception-page">
+      <div className="flex-between">
+        <div>
+          <h2>Recepción por códigos de barra</h2>
+          <p style={{ color: '#475569', marginTop: '-0.4rem' }}>
+            Seleccioná el depósito destino y escaneá cajas o unidades. Cada lectura suma 1 al artículo encontrado.
+          </p>
+        </div>
+        <span className="badge">Lecturas: {totalScans}</span>
+      </div>
+
+      {error && <ErrorMessage error={error} />}
+      {successMessage && <div className="success-message">{successMessage}</div>}
+
+      <div className="section-card">
+        <div className="form-grid form-grid--spaced">
+          <div className="input-group">
+            <label htmlFor="originLocationId">Origen</label>
+            <select id="originLocationId" value={originLocationId} onChange={event => setOriginLocationId(event.target.value)}>
+              <option value="">Seleccionar origen</option>
+              {activeOrigins.map(location => (
+                <option key={location.id} value={location.id}>{location.name}</option>
+              ))}
+            </select>
+            <p className="input-helper">Usá una ubicación de tipo “Origen externo”.</p>
+          </div>
+          <div className="input-group">
+            <label htmlFor="destinationLocationId">Depósito destino</label>
+            <select id="destinationLocationId" value={destinationLocationId} onChange={event => setDestinationLocationId(event.target.value)}>
+              <option value="">Seleccionar depósito</option>
+              {activeWarehouses.map(location => (
+                <option key={location.id} value={location.id}>{location.name}</option>
+              ))}
+            </select>
+          </div>
+          <div className="input-group">
+            <label htmlFor="scanMode">Cada lectura suma</label>
+            <select id="scanMode" value={scanMode} onChange={event => setScanMode(event.target.value)}>
+              {SCAN_MODE_OPTIONS.map(option => <option key={option.value} value={option.value}>{option.label}</option>)}
+            </select>
+          </div>
+        </div>
+      </div>
+
+      <div className="section-card barcode-scan-card">
+        <div className="input-group barcode-scan-input">
+          <label htmlFor="barcodeScan">Código escaneado</label>
+          <input
+            id="barcodeScan"
+            ref={scannerRef}
+            value={scanValue}
+            onChange={event => setScanValue(event.target.value)}
+            onKeyDown={handleScannerKeyDown}
+            autoComplete="off"
+            inputMode="none"
+            placeholder="Escaneá y presioná Enter"
+            disabled={scanning || saving}
+          />
+          <p className="input-helper">La lectora Bluetooth debe estar configurada como teclado y enviar Enter al finalizar.</p>
+        </div>
+        <div className="inline-actions">
+          <button type="button" onClick={handleScan} disabled={scanning || saving || !scanValue.trim()}>
+            {scanning ? 'Buscando…' : 'Agregar lectura'}
+          </button>
+          <button type="button" className="secondary-button" onClick={focusScanner}>Enfocar lector</button>
+        </div>
+        {scanMessage && <p className="barcode-scan-message">{scanMessage}</p>}
+      </div>
+
+      <div className="section-card">
+        <div className="flex-between">
+          <h3>Resumen de recepción</h3>
+          <div className="inline-actions">
+            <button type="button" className="secondary-button" disabled={lines.length === 0 || saving} onClick={() => setLines([])}>
+              Vaciar
+            </button>
+            <button type="button" disabled={lines.length === 0 || saving} onClick={handleConfirm}>
+              {saving ? 'Confirmando…' : 'Confirmar ingreso'}
+            </button>
+          </div>
+        </div>
+        {lines.length === 0 ? (
+          <p style={{ color: '#64748b' }}>Todavía no hay artículos escaneados.</p>
+        ) : (
+          <div className="table-wrapper">
+            <table>
+              <thead>
+                <tr>
+                  <th>Código</th>
+                  <th>Artículo</th>
+                  <th>Cajas</th>
+                  <th>Unidades</th>
+                  <th>Lecturas</th>
+                  <th>Acciones</th>
+                </tr>
+              </thead>
+              <tbody>
+                {lines.map(line => (
+                  <tr key={line.itemId}>
+                    <td>{line.code}</td>
+                    <td>{line.description}</td>
+                    <td>
+                      <input
+                        type="number"
+                        min="0"
+                        value={line.quantity.boxes}
+                        onChange={event => handleQuantityChange(line.itemId, 'boxes', event.target.value)}
+                        style={{ maxWidth: '90px' }}
+                      />
+                    </td>
+                    <td>
+                      <input
+                        type="number"
+                        min="0"
+                        value={line.quantity.units}
+                        onChange={event => handleQuantityChange(line.itemId, 'units', event.target.value)}
+                        style={{ maxWidth: '90px' }}
+                      />
+                    </td>
+                    <td>{line.scans}</td>
+                    <td>
+                      <div className="inline-actions">
+                        <span className="badge">{quantityLabel(line.quantity)}</span>
+                        <button type="button" className="danger-button" onClick={() => handleRemoveLine(line.itemId)}>Quitar</button>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
### Motivation

- Provide a fast workflow to confirm inbound stock by scanning barcodes so operators can create approved ingress movements from external origins to internal warehouses.

### Description

- Add a backend endpoint `POST /stock/barcode-reception` that validates payloads, enforces `stock.approve` permission, limits receptions to 200 lines, ensures origin is an `externalOrigin` and destination is a `warehouse`, creates approved `MovementRequest` records, logs movement events, executes movements and records an audit event.
- Import and use `ensureLocationExists` in `backend/src/routes/stock.js` and use existing helpers `findItemOrThrow`, `executeMovement`, `addMovementLog`, and `normalizeStoredQuantity` to process each scanned line.
- Add a new frontend page component `frontend/src/pages/items/BarcodeReceptionPage.jsx` implementing scan input, per-item quantity adjustments, origin/destination selectors, and confirm action; wire the page into the app routes (`/items/barcode-reception`) in `frontend/src/App.jsx` and add a sidebar item in `frontend/src/components/Sidebar.jsx` guarded by `stock.approve` permission.
- Add UI styles in `frontend/src/index.css` for the new page and scan controls.

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3146263374832a96b5dee74181731b)