### PR TITLE
Handle UPC-A (12-digit) barcode inputs and add SKU column/option to Items PDF/table

### DIFF
--- a/backend/src/routes/stock.js
+++ b/backend/src/routes/stock.js
@@ -40,26 +40,35 @@ function uniqueValues(values) {
 }
 
 function deriveSkusFromInternalEan13(value) {
-  const digits = String(value || '').replace(/\D/g, '');
-  if (!/^04\d{10}\d$/.test(digits)) {
-    return [];
-  }
-  const base12 = digits.slice(0, 12);
-  if (computeEan13CheckDigit(base12) !== digits[12]) {
-    return [];
-  }
+  const rawDigits = String(value || '').replace(/\D/g, '');
+  const eanCandidates = uniqueValues([
+    rawDigits,
+    // Algunos lectores envían los EAN-13 que empiezan con 0 como UPC-A de 12 dígitos.
+    rawDigits.length === 12 ? `0${rawDigits}` : null
+  ]);
 
-  const candidates = [];
-  // Formato actual: 04 + SKU de 6 dígitos + 0000 + verificador.
-  if (digits.slice(8, 12) === '0000') {
-    candidates.push(digits.slice(2, 8));
-  }
-  // Formato legado: 04 + SKU llevado a 7 dígitos + 000 + verificador.
-  // Como el SKU guardado es de 6 dígitos, se toma el final del segmento.
-  if (digits.slice(9, 12) === '000') {
-    candidates.push(digits.slice(2, 9).slice(-6));
-  }
-  return uniqueValues(candidates);
+  const skuCandidates = [];
+  eanCandidates.forEach(digits => {
+    if (!/^04\d{10}\d$/.test(digits)) {
+      return;
+    }
+    const base12 = digits.slice(0, 12);
+    if (computeEan13CheckDigit(base12) !== digits[12]) {
+      return;
+    }
+
+    // Formato actual: 04 + SKU de 6 dígitos + 0000 + verificador.
+    if (digits.slice(8, 12) === '0000') {
+      skuCandidates.push(digits.slice(2, 8));
+    }
+    // Formato legado: 04 + SKU llevado a 7 dígitos + 000 + verificador.
+    // Como el SKU guardado es de 6 dígitos, se toma el final del segmento.
+    if (digits.slice(9, 12) === '000') {
+      skuCandidates.push(digits.slice(2, 9).slice(-6));
+    }
+  });
+
+  return uniqueValues(skuCandidates);
 }
 
 function buildInternalEan13FromSku(sku) {

--- a/frontend/src/pages/items/BarcodeReceptionPage.jsx
+++ b/frontend/src/pages/items/BarcodeReceptionPage.jsx
@@ -24,6 +24,20 @@ function normalizeBarcodeValue(value) {
   return typeof value === 'string' ? value.replace(/\s+/g, '').trim() : '';
 }
 
+function getBarcodeSearchValues(value) {
+  const normalized = normalizeBarcodeValue(value);
+  if (!normalized) {
+    return [];
+  }
+  const digits = normalized.replace(/\D/g, '');
+  return Array.from(
+    new Set([
+      normalized,
+      digits.length === 12 ? `0${digits}` : null
+    ].filter(Boolean))
+  );
+}
+
 function normalizeItem(item) {
   return {
     id: item?.id || item?._id || '',
@@ -160,9 +174,10 @@ export default function BarcodeReceptionPage() {
     setError(null);
     setScanMessage('');
     try {
-      const response = await api.get('/stock/items', { query: { search: normalizedCode, limit: 10 } });
-      const matches = Array.isArray(response) ? response : [];
-      const scanned = normalizedCode.toLowerCase();
+      const searchValues = getBarcodeSearchValues(normalizedCode);
+      const responses = await Promise.all(searchValues.map(value => api.get('/stock/items', { query: { search: value, limit: 10 } })));
+      const matches = responses.flatMap(response => (Array.isArray(response) ? response : []));
+      const scannedValues = searchValues.map(value => value.toLowerCase());
       const getMatchScore = item => {
         const code = normalizeBarcodeValue(item.code).toLowerCase();
         const sku = normalizeBarcodeValue(item.sku).toLowerCase();
@@ -170,10 +185,10 @@ export default function BarcodeReceptionPage() {
         const legacyInternalBarcode = normalizeBarcodeValue(buildLegacyItemEan13(item.sku)).toLowerCase();
         const returnedBarcodes = (Array.isArray(item.internalBarcodes) ? item.internalBarcodes : [])
           .map(value => normalizeBarcodeValue(value).toLowerCase());
-        if (code === scanned || sku === scanned) return 4;
-        if (legacyInternalBarcode === scanned) return 3;
-        if (currentInternalBarcode === scanned) return 2;
-        if (returnedBarcodes.includes(scanned)) return 1;
+        if (scannedValues.includes(code) || scannedValues.includes(sku)) return 4;
+        if (scannedValues.includes(legacyInternalBarcode)) return 3;
+        if (scannedValues.includes(currentInternalBarcode)) return 2;
+        if (returnedBarcodes.some(barcode => scannedValues.includes(barcode))) return 1;
         return 0;
       };
       const exactMatch = matches

--- a/frontend/src/pages/items/ItemsDownloadPage.jsx
+++ b/frontend/src/pages/items/ItemsDownloadPage.jsx
@@ -253,6 +253,7 @@ export default function ItemsDownloadPage() {
   const [filters, setFilters] = useState({ search: '', groupId: '', gender: '', size: '', color: '' });
   const [printing, setPrinting] = useState(false);
   const [selectedItemsForPrint, setSelectedItemsForPrint] = useState({});
+  const [includeSkuInPdf, setIncludeSkuInPdf] = useState(false);
 
   const totalPages = Math.max(1, Math.ceil(total / pageSize));
 
@@ -342,6 +343,7 @@ export default function ItemsDownloadPage() {
           id: item.id,
           ean13: buildItemEan13(item.sku, item.unitsPerBox),
           code: item.code || '-',
+          sku: item.sku || '-',
           description: item.description || '-'
         }
       };
@@ -361,6 +363,7 @@ export default function ItemsDownloadPage() {
           id: item.id,
           ean13: buildItemEan13(item.sku, item.unitsPerBox),
           code: item.code || '-',
+          sku: item.sku || '-',
           description: item.description || '-'
         };
       });
@@ -509,6 +512,7 @@ export default function ItemsDownloadPage() {
         id: item.id,
         ean13: buildItemEan13(item.sku, item.unitsPerBox),
         code: item.code || '-',
+        sku: item.sku || '-',
         description: item.description || '-'
       };
       setSelectedItemsForPrint(prev => ({ ...prev, [item.id]: singleItemPayload }));
@@ -559,6 +563,7 @@ export default function ItemsDownloadPage() {
             <tr>
               <td>${escapeHtml(item.ean13 || '-')}</td>
               <td>${escapeHtml(item.code || '-')}</td>
+              ${includeSkuInPdf ? `<td>${escapeHtml(item.sku || '-')}</td>` : ''}
               <td>${escapeHtml(item.description || '-')}</td>
             </tr>
           `;
@@ -597,6 +602,7 @@ export default function ItemsDownloadPage() {
                 <tr>
                   <th>EAN13</th>
                   <th>Artículo</th>
+                  ${includeSkuInPdf ? '<th>SKU</th>' : ''}
                   <th>Descripción</th>
                 </tr>
               </thead>
@@ -641,6 +647,14 @@ export default function ItemsDownloadPage() {
         <div className="flex-between">
           <h2>Buscar artículos para descarga o impresión</h2>
           <div className="inline-actions">
+            <label style={{ display: 'inline-flex', gap: '0.5rem', alignItems: 'center', color: '#475569', fontSize: '0.85rem' }}>
+              <input
+                type="checkbox"
+                checked={includeSkuInPdf}
+                onChange={event => setIncludeSkuInPdf(event.target.checked)}
+              />
+              Mostrar SKU en PDF
+            </label>
             <button
               type="button"
               className="secondary-button"
@@ -793,6 +807,7 @@ export default function ItemsDownloadPage() {
                   <th>Seleccionar</th>
                   <th>EAN13</th>
                   <th>Artículo</th>
+                  {includeSkuInPdf && <th>SKU</th>}
                   <th>Descripción</th>
                   <th>Etiqueta</th>
                 </tr>
@@ -812,6 +827,7 @@ export default function ItemsDownloadPage() {
                       </td>
                       <td>{buildItemEan13(item.sku, item.unitsPerBox) || '-'}</td>
                       <td>{item.code}</td>
+                      {includeSkuInPdf && <td>{item.sku || '-'}</td>}
                       <td>{item.description}</td>
                       <td>
                         <button type="button" className="secondary-button" onClick={() => handlePrintSingleLabel(item)}>
@@ -823,7 +839,7 @@ export default function ItemsDownloadPage() {
                 })}
                 {items.length === 0 && (
                   <tr>
-                    <td colSpan={5} style={{ textAlign: 'center', padding: '1.5rem 0' }}>
+                    <td colSpan={includeSkuInPdf ? 6 : 5} style={{ textAlign: 'center', padding: '1.5rem 0' }}>
                       No se encontraron artículos para los filtros seleccionados.
                     </td>
                   </tr>


### PR DESCRIPTION
### Motivation

- Accept barcode scans that may arrive as 12-digit UPC-A values (readers that drop a leading zero) and derive SKUs reliably from both 12- and 13-digit forms. 
- Improve matching logic when scanning barcodes so searches try candidate forms (UPC-A vs EAN-13) and find the best item match. 
- Allow including the `sku` column when printing or downloading the selected items list and show/hide it in the items table.

### Description

- Enhanced `deriveSkusFromInternalEan13` to normalize digits, consider 12-digit UPC-A candidates by prepending a `0`, validate check digits using `computeEan13CheckDigit`, and return unique SKU candidates. 
- Added `getBarcodeSearchValues` helper to generate search variants (original value and `0`-prefixed 12-digit candidate) and updated barcode lookup in `BarcodeReceptionPage.jsx` to query all variants concurrently and score matches against multiple returned/barcode variants. 
- Adjusted matching logic to compare against arrays of scanned candidate values and prioritize matches by code/sku, legacy internal barcode, current internal barcode, and returned barcodes. 
- In `ItemsDownloadPage.jsx` added `includeSkuInPdf` state with a checkbox toggle, included `sku` in the selection payload, and conditionally render the `SKU` column in the table and in the generated PDF output. 

### Testing

- Ran frontend test suite with `npm test` in `frontend`, and the tests completed successfully. 
- Ran backend test suite with `npm test` in `backend`, and the tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a318ec73160832a9cca54402927fa77)