### PR TITLE
Support reception and request operations in barcode page; add movement type handling

### DIFF
--- a/frontend/src/pages/items/BarcodeReceptionPage.jsx
+++ b/frontend/src/pages/items/BarcodeReceptionPage.jsx
@@ -4,10 +4,16 @@ import { useAuth } from '../../context/AuthContext.jsx';
 import LoadingIndicator from '../../components/LoadingIndicator.jsx';
 import ErrorMessage from '../../components/ErrorMessage.jsx';
 import { buildItemEan13, buildLegacyItemEan13 } from '../../utils/ean13.js';
+import { MOVEMENT_TYPE_BADGE_CLASS, MOVEMENT_TYPE_LABELS, resolveMovementType, locationTypeSuffix } from '../../utils/movements.js';
 
 const SCAN_MODE_OPTIONS = [
   { value: 'boxes', label: 'Cajas' },
   { value: 'units', label: 'Unidades' }
+];
+
+const OPERATION_OPTIONS = [
+  { value: 'reception', label: 'Recepción directa' },
+  { value: 'request', label: 'Solicitud de movimiento' }
 ];
 
 function normalizeLocation(location) {
@@ -66,14 +72,19 @@ export default function BarcodeReceptionPage() {
   const { user } = useAuth();
   const permissions = useMemo(() => user?.permissions || [], [user]);
   const canReceive = permissions.includes('stock.approve');
+  const canRequest = permissions.includes('stock.request');
+  const hasRestrictedRequesterRole = ['Operador', 'Supervisor'].includes(user?.role);
+  const hasRequesterRestrictions = hasRestrictedRequesterRole && canRequest;
 
   const scannerRef = useRef(null);
   const [loading, setLoading] = useState(true);
   const [locations, setLocations] = useState([]);
+  const [operationMode, setOperationMode] = useState(canReceive ? 'reception' : 'request');
   const [originLocationId, setOriginLocationId] = useState('');
   const [destinationLocationId, setDestinationLocationId] = useState('');
   const [scanMode, setScanMode] = useState('boxes');
   const [scanValue, setScanValue] = useState('');
+  const [reason, setReason] = useState('');
   const [lines, setLines] = useState([]);
   const [error, setError] = useState(null);
   const [successMessage, setSuccessMessage] = useState('');
@@ -89,6 +100,46 @@ export default function BarcodeReceptionPage() {
     () => locations.filter(location => location.type === 'warehouse' && location.status !== 'inactive'),
     [locations]
   );
+  const activeLocations = useMemo(
+    () => locations.filter(location => location.status !== 'inactive'),
+    [locations]
+  );
+  const requestOrigins = useMemo(
+    () => activeLocations.filter(location => (hasRequesterRestrictions ? location.type === 'warehouse' : ['warehouse', 'externalOrigin'].includes(location.type))),
+    [activeLocations, hasRequesterRestrictions]
+  );
+  const requestDestinations = useMemo(
+    () => activeLocations.filter(location => ['warehouse', 'external'].includes(location.type)),
+    [activeLocations]
+  );
+  const selectedOrigin = useMemo(() => locations.find(location => location.id === originLocationId), [locations, originLocationId]);
+  const selectedDestination = useMemo(() => locations.find(location => location.id === destinationLocationId), [locations, destinationLocationId]);
+  const currentMovementType = useMemo(() => {
+    if (!selectedOrigin || !selectedDestination) return null;
+    return resolveMovementType({ fromType: selectedOrigin.type, toType: selectedDestination.type });
+  }, [selectedDestination, selectedOrigin]);
+
+
+  useEffect(() => {
+    if (operationMode === 'reception' && !canReceive && canRequest) {
+      setOperationMode('request');
+      return;
+    }
+    if (operationMode === 'request' && !canRequest && canReceive) {
+      setOperationMode('reception');
+    }
+  }, [canReceive, canRequest, operationMode]);
+
+  useEffect(() => {
+    const originOptions = operationMode === 'reception' ? activeOrigins : requestOrigins;
+    const destinationOptions = operationMode === 'reception' ? activeWarehouses : requestDestinations;
+    if (originOptions.length > 0 && !originOptions.some(location => location.id === originLocationId)) {
+      setOriginLocationId(originOptions[0].id);
+    }
+    if (destinationOptions.length > 0 && !destinationOptions.some(location => location.id === destinationLocationId)) {
+      setDestinationLocationId(destinationOptions[0].id);
+    }
+  }, [activeOrigins, activeWarehouses, destinationLocationId, operationMode, originLocationId, requestDestinations, requestOrigins]);
 
   const focusScanner = useCallback(() => {
     window.setTimeout(() => scannerRef.current?.focus(), 0);
@@ -100,7 +151,7 @@ export default function BarcodeReceptionPage() {
       setLoading(true);
       setError(null);
       try {
-        const response = await api.get('/locations');
+        const response = await api.get('/stock/locations');
         if (!active) return;
         const normalized = Array.isArray(response)
           ? response.map(normalizeLocation).sort((a, b) => a.name.localeCompare(b.name, 'es', { sensitivity: 'base' }))
@@ -108,7 +159,7 @@ export default function BarcodeReceptionPage() {
         setLocations(normalized);
         const firstOrigin = normalized.find(location => location.type === 'externalOrigin' && location.status !== 'inactive');
         const firstWarehouse = normalized.find(location => location.type === 'warehouse' && location.status !== 'inactive');
-        setOriginLocationId(firstOrigin?.id || '');
+        setOriginLocationId(firstOrigin?.id || firstWarehouse?.id || '');
         setDestinationLocationId(firstWarehouse?.id || '');
       } catch (err) {
         if (active) setError(err);
@@ -165,6 +216,30 @@ export default function BarcodeReceptionPage() {
     [scanMode]
   );
 
+  const findItemByBarcode = useCallback(async barcode => {
+    const searchValues = getBarcodeSearchValues(barcode);
+    const responses = await Promise.all(searchValues.map(value => api.get('/stock/items', { query: { search: value, limit: 10 } })));
+    const matches = responses.flatMap(response => (Array.isArray(response) ? response : []));
+    const scannedValues = searchValues.map(value => value.toLowerCase());
+    const getMatchScore = item => {
+      const code = normalizeBarcodeValue(item.code).toLowerCase();
+      const sku = normalizeBarcodeValue(item.sku).toLowerCase();
+      const currentInternalBarcode = normalizeBarcodeValue(item.internalBarcode || buildItemEan13(item.sku)).toLowerCase();
+      const legacyInternalBarcode = normalizeBarcodeValue(buildLegacyItemEan13(item.sku)).toLowerCase();
+      const returnedBarcodes = (Array.isArray(item.internalBarcodes) ? item.internalBarcodes : [])
+        .map(value => normalizeBarcodeValue(value).toLowerCase());
+      if (scannedValues.includes(code) || scannedValues.includes(sku)) return 4;
+      if (scannedValues.includes(legacyInternalBarcode)) return 3;
+      if (scannedValues.includes(currentInternalBarcode)) return 2;
+      if (returnedBarcodes.some(barcodeValue => scannedValues.includes(barcodeValue))) return 1;
+      return 0;
+    };
+    return matches
+      .map(item => ({ item, score: getMatchScore(item) }))
+      .filter(match => match.score > 0)
+      .sort((a, b) => b.score - a.score)[0]?.item || null;
+  }, [api]);
+
   const handleScan = useCallback(async () => {
     const normalizedCode = normalizeBarcodeValue(scanValue);
     if (!normalizedCode || scanning) {
@@ -174,27 +249,7 @@ export default function BarcodeReceptionPage() {
     setError(null);
     setScanMessage('');
     try {
-      const searchValues = getBarcodeSearchValues(normalizedCode);
-      const responses = await Promise.all(searchValues.map(value => api.get('/stock/items', { query: { search: value, limit: 10 } })));
-      const matches = responses.flatMap(response => (Array.isArray(response) ? response : []));
-      const scannedValues = searchValues.map(value => value.toLowerCase());
-      const getMatchScore = item => {
-        const code = normalizeBarcodeValue(item.code).toLowerCase();
-        const sku = normalizeBarcodeValue(item.sku).toLowerCase();
-        const currentInternalBarcode = normalizeBarcodeValue(item.internalBarcode || buildItemEan13(item.sku)).toLowerCase();
-        const legacyInternalBarcode = normalizeBarcodeValue(buildLegacyItemEan13(item.sku)).toLowerCase();
-        const returnedBarcodes = (Array.isArray(item.internalBarcodes) ? item.internalBarcodes : [])
-          .map(value => normalizeBarcodeValue(value).toLowerCase());
-        if (scannedValues.includes(code) || scannedValues.includes(sku)) return 4;
-        if (scannedValues.includes(legacyInternalBarcode)) return 3;
-        if (scannedValues.includes(currentInternalBarcode)) return 2;
-        if (returnedBarcodes.some(barcode => scannedValues.includes(barcode))) return 1;
-        return 0;
-      };
-      const exactMatch = matches
-        .map(item => ({ item, score: getMatchScore(item) }))
-        .filter(match => match.score > 0)
-        .sort((a, b) => b.score - a.score)[0]?.item;
+      const exactMatch = await findItemByBarcode(normalizedCode);
       if (!exactMatch) {
         setScanMessage(`No se encontró un artículo activo con el código ${normalizedCode}.`);
         return;
@@ -207,7 +262,7 @@ export default function BarcodeReceptionPage() {
       setScanning(false);
       focusScanner();
     }
-  }, [addScannedItem, api, focusScanner, scanValue, scanning]);
+  }, [addScannedItem, findItemByBarcode, focusScanner, scanValue, scanning]);
 
   const handleScannerKeyDown = event => {
     if (event.key === 'Enter') {
@@ -215,6 +270,7 @@ export default function BarcodeReceptionPage() {
       handleScan();
     }
   };
+
 
   const handleQuantityChange = (itemId, field, value) => {
     if (value !== '') {
@@ -238,9 +294,11 @@ export default function BarcodeReceptionPage() {
   const totalScans = useMemo(() => lines.reduce((sum, line) => sum + (Number(line.scans) || 0), 0), [lines]);
 
   const handleConfirm = async () => {
-    if (!canReceive || saving) return;
+    if (saving) return;
+    if (operationMode === 'reception' && !canReceive) return;
+    if (operationMode === 'request' && !canRequest) return;
     if (!originLocationId || !destinationLocationId) {
-      setError(new Error('Seleccioná un origen externo y un depósito destino.'));
+      setError(new Error('Seleccioná origen y destino.'));
       return;
     }
     const payloadLines = lines
@@ -260,15 +318,38 @@ export default function BarcodeReceptionPage() {
     setError(null);
     setSuccessMessage('');
     try {
-      const response = await api.post('/stock/barcode-reception', {
-        fromLocation: originLocationId,
-        toLocation: destinationLocationId,
-        lines: payloadLines
-      });
-      setSuccessMessage(`Recepción confirmada: ${response.lines?.length || payloadLines.length} artículo(s) ingresados.`);
+      if (originLocationId === destinationLocationId) {
+        throw new Error('La ubicación de origen y destino no pueden ser la misma.');
+      }
+      if (operationMode === 'request' && hasRequesterRestrictions) {
+        const isFromWarehouse = selectedOrigin?.type === 'warehouse';
+        const isToAllowed = ['warehouse', 'external'].includes(selectedDestination?.type);
+        if (!isFromWarehouse || !isToAllowed) {
+          throw new Error('Como operador o supervisor solo puede solicitar desde depósitos internos hacia depósitos internos o externos.');
+        }
+      }
+      if (operationMode === 'reception') {
+        const response = await api.post('/stock/barcode-reception', {
+          fromLocation: originLocationId,
+          toLocation: destinationLocationId,
+          lines: payloadLines,
+          reason
+        });
+        setSuccessMessage(`Recepción confirmada: ${response.lines?.length || payloadLines.length} artículo(s) ingresados.`);
+      } else {
+        await Promise.all(payloadLines.map(line => api.post('/stock/request', {
+          itemId: line.itemId,
+          fromLocation: originLocationId,
+          toLocation: destinationLocationId,
+          quantity: line.quantity,
+          reason
+        })));
+        setSuccessMessage(`Solicitudes registradas: ${payloadLines.length} artículo(s).`);
+      }
       setLines([]);
       setScanValue('');
-      setScanMessage('Listo para escanear la próxima recepción.');
+      setReason('');
+      setScanMessage('Listo para escanear la próxima operación.');
     } catch (err) {
       setError(err);
     } finally {
@@ -281,11 +362,11 @@ export default function BarcodeReceptionPage() {
     return <LoadingIndicator message="Cargando recepción por códigos…" />;
   }
 
-  if (!canReceive) {
+  if (!canReceive && !canRequest) {
     return (
       <div className="section-card">
-        <h2>Recepción por códigos de barra</h2>
-        <ErrorMessage error="Necesitás permiso de aprobación de stock para confirmar recepciones." />
+        <h2>Movimientos por códigos de barra</h2>
+        <ErrorMessage error="Necesitás permiso de stock para operar con códigos de barra." />
       </div>
     );
   }
@@ -294,9 +375,9 @@ export default function BarcodeReceptionPage() {
     <div className="barcode-reception-page">
       <div className="flex-between">
         <div>
-          <h2>Recepción por códigos de barra</h2>
+          <h2>Movimientos por códigos de barra</h2>
           <p style={{ color: '#475569', marginTop: '-0.4rem' }}>
-            Seleccioná el depósito destino y escaneá cajas o unidades. Cada lectura suma 1 al artículo encontrado.
+            Seleccioná la operación, origen y destino. Cada lectura de código de barra baja a la grilla y suma 1 al artículo encontrado.
           </p>
         </div>
         <span className="badge">Lecturas: {totalScans}</span>
@@ -308,21 +389,29 @@ export default function BarcodeReceptionPage() {
       <div className="section-card">
         <div className="form-grid form-grid--spaced">
           <div className="input-group">
+            <label htmlFor="operationMode">Operación</label>
+            <select id="operationMode" value={operationMode} onChange={event => setOperationMode(event.target.value)}>
+              {OPERATION_OPTIONS.filter(option => (option.value === 'reception' ? canReceive : canRequest)).map(option => (
+                <option key={option.value} value={option.value}>{option.label}</option>
+              ))}
+            </select>
+          </div>
+          <div className="input-group">
             <label htmlFor="originLocationId">Origen</label>
             <select id="originLocationId" value={originLocationId} onChange={event => setOriginLocationId(event.target.value)}>
               <option value="">Seleccionar origen</option>
-              {activeOrigins.map(location => (
-                <option key={location.id} value={location.id}>{location.name}</option>
+              {(operationMode === 'reception' ? activeOrigins : requestOrigins).map(location => (
+                <option key={location.id} value={location.id}>{location.name}{locationTypeSuffix(location.type)}</option>
               ))}
             </select>
-            <p className="input-helper">Usá una ubicación de tipo “Origen externo”.</p>
+            <p className="input-helper">Para baja elegí un destino externo; para movimiento elegí depósitos internos.</p>
           </div>
           <div className="input-group">
             <label htmlFor="destinationLocationId">Depósito destino</label>
             <select id="destinationLocationId" value={destinationLocationId} onChange={event => setDestinationLocationId(event.target.value)}>
               <option value="">Seleccionar depósito</option>
-              {activeWarehouses.map(location => (
-                <option key={location.id} value={location.id}>{location.name}</option>
+              {(operationMode === 'reception' ? activeWarehouses : requestDestinations).map(location => (
+                <option key={location.id} value={location.id}>{location.name}{locationTypeSuffix(location.type)}</option>
               ))}
             </select>
           </div>
@@ -331,6 +420,15 @@ export default function BarcodeReceptionPage() {
             <select id="scanMode" value={scanMode} onChange={event => setScanMode(event.target.value)}>
               {SCAN_MODE_OPTIONS.map(option => <option key={option.value} value={option.value}>{option.label}</option>)}
             </select>
+            {currentMovementType && (
+              <span className={`badge ${MOVEMENT_TYPE_BADGE_CLASS[currentMovementType] || MOVEMENT_TYPE_BADGE_CLASS.transfer}`}>
+                {MOVEMENT_TYPE_LABELS[currentMovementType]}
+              </span>
+            )}
+          </div>
+          <div className="input-group" style={{ gridColumn: '1 / -1' }}>
+            <label htmlFor="reason">Motivo</label>
+            <textarea id="reason" value={reason} onChange={event => setReason(event.target.value)} rows={2} placeholder="Opcional" />
           </div>
         </div>
       </div>
@@ -362,13 +460,13 @@ export default function BarcodeReceptionPage() {
 
       <div className="section-card">
         <div className="flex-between">
-          <h3>Resumen de recepción</h3>
+          <h3>Resumen de operación</h3>
           <div className="inline-actions">
             <button type="button" className="secondary-button" disabled={lines.length === 0 || saving} onClick={() => setLines([])}>
               Vaciar
             </button>
             <button type="button" disabled={lines.length === 0 || saving} onClick={handleConfirm}>
-              {saving ? 'Confirmando…' : 'Confirmar ingreso'}
+              {saving ? 'Confirmando…' : operationMode === 'reception' ? 'Confirmar ingreso' : 'Registrar solicitudes'}
             </button>
           </div>
         </div>


### PR DESCRIPTION
### Motivation
- Extend the barcode reception page to support both direct receptions and movement requests from the same UI. 
- Enforce permissions and requester-role restrictions so operators/supervisors can only create allowed requests. 
- Provide clearer movement-type feedback in the UI and include an optional `reason` for operations.

### Description
- Added operation mode selection (`reception` / `request`) with `OPERATION_OPTIONS` and state `operationMode`, and gate options by `canReceive` and `canRequest` permissions. 
- Reworked location logic to load from `'/stock/locations'`, populate origin/destination options per mode, preserve sensible defaults, and show location type suffix using `locationTypeSuffix`. 
- Extracted barcode lookup into `findItemByBarcode` and reuse it from `handleScan`; search uses `getBarcodeSearchValues` and scores matches by code/sku/internal barcodes. 
- Implemented dual submit behavior in `handleConfirm`: for `reception` POST to `'/stock/barcode-reception'` (including `reason`), and for `request` POST per-line to `'/stock/request'`; added validation for identical origin/destination and role-based restrictions. 
- UI updates: change headings and helper texts to generic movement wording, add `Motivo` textarea, show movement-type badge via `MOVEMENT_TYPE_LABELS`/`MOVEMENT_TYPE_BADGE_CLASS`, and update labels/buttons to reflect current operation. 

### Testing
- Ran frontend unit tests with `yarn test` and all tests passed. 
- Ran linter with `yarn lint` and no lint errors remained. 
- Executed a local build and smoke-tested the barcode flow in both `reception` and `request` modes; no runtime errors observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a358243d9c8832a8de8710fb37fde53)