### PR TITLE
Actualizar textos: 'Descarga PDF' → 'PDF e Impresión' y 'Depósito destino' → 'Destino'

### DIFF
--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -7,7 +7,7 @@ const NAV_ITEMS = [
   { to: '/items/barcode-reception', label: 'Recepción por código', permission: 'stock.approve', hiddenForRoles: ['Operador'] },
   { to: '/overstock', label: 'Sobrestock', permission: 'items.read', hiddenForRoles: ['Operador'] },
   { to: '/items/trash', label: 'Papelera', permission: 'items.write', hiddenForRoles: ['Operador'] },
-  { to: '/items/download', label: 'Descarga PDF', permission: 'items.read', hiddenForRoles: ['Operador', 'Supervisor'] },
+  { to: '/items/download', label: 'PDF e Impresión', permission: 'items.read', hiddenForRoles: ['Operador', 'Supervisor'] },
   { to: '/groups', label: 'Grupos', permission: 'items.write', hiddenForRoles: ['Operador'] },
   { to: '/requests', label: 'Solicitudes', permission: 'stock.request' },
   { to: '/approvals', label: 'Aprobaciones', permission: 'stock.approve', hiddenForRoles: ['Operador'] },

--- a/frontend/src/pages/items/BarcodeReceptionPage.jsx
+++ b/frontend/src/pages/items/BarcodeReceptionPage.jsx
@@ -240,7 +240,7 @@ export default function BarcodeReceptionPage() {
   const handleConfirm = async () => {
     if (!canReceive || saving) return;
     if (!originLocationId || !destinationLocationId) {
-      setError(new Error('Seleccioná un origen externo y un depósito destino.'));
+      setError(new Error('Seleccioná un origen externo y un destino.'));
       return;
     }
     const payloadLines = lines
@@ -296,7 +296,7 @@ export default function BarcodeReceptionPage() {
         <div>
           <h2>Recepción por códigos de barra</h2>
           <p style={{ color: '#475569', marginTop: '-0.4rem' }}>
-            Seleccioná el depósito destino y escaneá cajas o unidades. Cada lectura suma 1 al artículo encontrado.
+            Seleccioná el destino y escaneá cajas o unidades. Cada lectura suma 1 al artículo encontrado.
           </p>
         </div>
         <span className="badge">Lecturas: {totalScans}</span>
@@ -318,7 +318,7 @@ export default function BarcodeReceptionPage() {
             <p className="input-helper">Usá una ubicación de tipo “Origen externo”.</p>
           </div>
           <div className="input-group">
-            <label htmlFor="destinationLocationId">Depósito destino</label>
+            <label htmlFor="destinationLocationId">Destino</label>
             <select id="destinationLocationId" value={destinationLocationId} onChange={event => setDestinationLocationId(event.target.value)}>
               <option value="">Seleccionar depósito</option>
               {activeWarehouses.map(location => (


### PR DESCRIPTION
### Motivation
- Aclarar y unificar la redacción en la interfaz renombrando el ítem de menú de descarga y reemplazando el literal "Depósito destino" por "Destino" en la página de recepción por código de barras para mejorar consistencia y usabilidad.

### Description
- Se actualizó el label del menú en `frontend/src/components/Sidebar.jsx` de `Descarga PDF` a `PDF e Impresión` y se reemplazaron las cadenas y el label relacionados en `frontend/src/pages/items/BarcodeReceptionPage.jsx` para usar `Destino` (mensajes, helper y validación de formulario).

### Testing
- Se ejecutó la compilación de frontend con `npm run build` en `frontend` y finalizó correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35832a29d0832aba5951fd951f3724)