### PR TITLE
Renombrar ‘Recepción por código’ a ‘Escaneo de Productos’ en el sidebar

### DIFF
--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -4,7 +4,7 @@ import { useAuth } from '../context/AuthContext.jsx';
 const NAV_ITEMS = [
   { to: '/', label: 'Resumen' },
   { to: '/items', label: 'Artículos', permission: 'items.read', hiddenForRoles: ['Operador'] },
-  { to: '/items/barcode-reception', label: 'Recepción por código', permission: 'stock.approve', hiddenForRoles: ['Operador'] },
+  { to: '/items/barcode-reception', label: 'Escaneo de Productos', permission: 'stock.approve', hiddenForRoles: ['Operador'] },
   { to: '/overstock', label: 'Sobrestock', permission: 'items.read', hiddenForRoles: ['Operador'] },
   { to: '/items/trash', label: 'Papelera', permission: 'items.write', hiddenForRoles: ['Operador'] },
   { to: '/items/download', label: 'PDF e Impresión', permission: 'items.read', hiddenForRoles: ['Operador', 'Supervisor'] },


### PR DESCRIPTION
### Motivation
- Cambiar el texto del enlace del menú para reflejar que la funcionalidad es un escaneo de productos en lugar de una "recepción por código".

### Description
- Se actualizó la etiqueta del elemento de navegación en `frontend/src/components/Sidebar.jsx` de `Recepción por código` a `Escaneo de Productos`.

### Testing
- Se ejecutó `npm run build` en `frontend` y la compilación produjo el `dist` sin errores.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3591f43c2c832a89261bc0a8ddfbf6)