### PR TITLE
Print: use standalone window on touch/mobile and fall back to hidden iframe

### DIFF
--- a/frontend/src/pages/items/ItemsDownloadPage.jsx
+++ b/frontend/src/pages/items/ItemsDownloadPage.jsx
@@ -196,7 +196,52 @@ function buildEan13SvgMarkup(ean13) {
 }
 
 
+function shouldUseStandalonePrintWindow() {
+  if (typeof navigator === 'undefined' || typeof window === 'undefined') {
+    return false;
+  }
+  const userAgent = navigator.userAgent || '';
+  return /Android|iPhone|iPad|iPod/i.test(userAgent) || (navigator.maxTouchPoints > 1 && window.innerWidth <= 900);
+}
+
+function printHtmlInStandaloneWindow(html) {
+  return new Promise((resolve, reject) => {
+    const printWindow = window.open('', '_blank');
+    if (!printWindow) {
+      reject(new Error('No se pudo abrir la ventana de impresión. Verificá si el navegador bloqueó la ventana emergente.'));
+      return;
+    }
+
+    const cleanup = () => {
+      try {
+        printWindow.close();
+      } catch (error) {
+        console.warn('No se pudo cerrar la ventana de impresión', error);
+      }
+    };
+
+    try {
+      printWindow.document.open();
+      printWindow.document.write(html);
+      printWindow.document.close();
+      printWindow.addEventListener('afterprint', cleanup, { once: true });
+      printWindow.setTimeout(() => {
+        printWindow.focus();
+        printWindow.print();
+        resolve();
+      }, 250);
+    } catch (error) {
+      cleanup();
+      reject(error);
+    }
+  });
+}
+
 function printHtmlInHiddenFrame(html) {
+  if (shouldUseStandalonePrintWindow()) {
+    return printHtmlInStandaloneWindow(html);
+  }
+
   return new Promise((resolve, reject) => {
     const printFrame = document.createElement('iframe');
     printFrame.setAttribute('aria-hidden', 'true');


### PR DESCRIPTION
### Motivation
- Improve printing reliability on mobile and touch-enabled devices where hidden iframes can fail or be blocked by the browser.

### Description
- Added `shouldUseStandalonePrintWindow` to detect mobile/touch contexts by inspecting `navigator.userAgent`, `navigator.maxTouchPoints`, and `window.innerWidth`.
- Implemented `printHtmlInStandaloneWindow` to open a new window, write the print HTML, trigger print, and clean up after `afterprint` or on error with descriptive error messages.
- Updated `printHtmlInHiddenFrame` to call `printHtmlInStandaloneWindow` when `shouldUseStandalonePrintWindow()` returns true and otherwise retain the existing iframe-based printing flow.
- Kept existing cleanup behavior using `afterprint` handlers and timeouts to remove the print frame or close the print window.

### Testing
- Ran linting and the frontend unit test suite with `yarn lint` and `yarn test`, and they passed.
- Verified the new functions do not break the iframe path by exercising the print codepath in a desktop browser environment via automated test harness (tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3940b14884832a9e3d65d017a1a7c8)