### PR TITLE
Add mobile-aware printing: print in current document on mobile and fallback to hidden iframe

### DIFF
--- a/frontend/src/pages/items/ItemsDownloadPage.jsx
+++ b/frontend/src/pages/items/ItemsDownloadPage.jsx
@@ -196,7 +196,58 @@ function buildEan13SvgMarkup(ean13) {
 }
 
 
+function shouldPrintInCurrentDocumentOnMobile() {
+  if (typeof navigator === 'undefined' || typeof window === 'undefined') {
+    return false;
+  }
+  const userAgent = navigator.userAgent || '';
+  return /Android|iPhone|iPad|iPod/i.test(userAgent) || (navigator.maxTouchPoints > 1 && window.innerWidth <= 900);
+}
+
+function printHtmlInCurrentDocument(html) {
+  return new Promise((resolve, reject) => {
+    try {
+      const parser = new DOMParser();
+      const printableDocument = parser.parseFromString(html, 'text/html');
+      const printRoot = document.createElement('div');
+      const printStyle = document.createElement('style');
+
+      printRoot.className = 'mobile-label-print-root';
+      printRoot.setAttribute('aria-hidden', 'true');
+      printRoot.innerHTML = printableDocument.body.innerHTML;
+      printStyle.textContent = `
+        ${Array.from(printableDocument.querySelectorAll('style')).map(style => style.textContent).join('\n')}
+        @media screen { .mobile-label-print-root { display: none !important; } }
+        @media print {
+          body > *:not(.mobile-label-print-root) { display: none !important; }
+          .mobile-label-print-root { display: block !important; }
+        }
+      `;
+
+      const cleanup = () => {
+        printRoot.remove();
+        printStyle.remove();
+      };
+
+      window.addEventListener('afterprint', cleanup, { once: true });
+      document.head.appendChild(printStyle);
+      document.body.appendChild(printRoot);
+      window.setTimeout(cleanup, 60000);
+      window.setTimeout(() => {
+        window.print();
+        resolve();
+      }, 100);
+    } catch (error) {
+      reject(error);
+    }
+  });
+}
+
 function printHtmlInHiddenFrame(html) {
+  if (shouldPrintInCurrentDocumentOnMobile()) {
+    return printHtmlInCurrentDocument(html);
+  }
+
   return new Promise((resolve, reject) => {
     const printFrame = document.createElement('iframe');
     printFrame.setAttribute('aria-hidden', 'true');


### PR DESCRIPTION
### Motivation

- Improve printing behavior on mobile/touch devices where printing from an offscreen iframe can fail or be unsupported.
- Ensure printable content is accessible to the print dialog on phones/tablets while preserving the existing hidden iframe fallback for desktops.

### Description

- Added `shouldPrintInCurrentDocumentOnMobile()` to detect mobile/touch environments by checking `navigator.userAgent`, `navigator.maxTouchPoints`, and `window.innerWidth`.
- Implemented `printHtmlInCurrentDocument(html)` which injects a `.mobile-label-print-root` container and inline print styles, attaches `afterprint` cleanup, and triggers `window.print()` with timeouts for removal.
- Updated `printHtmlInHiddenFrame(html)` to call `printHtmlInCurrentDocument(html)` when the mobile detection returns true, otherwise keep the existing hidden iframe printing flow.
- Preserved accessibility attributes and added safe cleanup timeouts to avoid leaving DOM artifacts after printing.

### Testing

- Ran frontend unit tests via `npm test`, which completed successfully.
- Ran linting via `npm run lint`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3940b14884832a9e3d65d017a1a7c8)