### PR TITLE
docs: aclarar que la impresión directa de etiquetas no incluye flujo Bluetooth

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,3 +276,5 @@ La pantalla de etiquetas imprime cada EAN-13 en una página física de 100 × 10
    ```
 
 Sin `--kiosk-printing`, los navegadores muestran obligatoriamente su diálogo de impresión. La aplicación genera el trabajo en un marco oculto y no abre una pestaña o ventana adicional.
+
+> Nota: la impresión de etiquetas se mantiene con el flujo del navegador y la impresora configurada; no incluye un flujo Bluetooth propio dentro de la aplicación.


### PR DESCRIPTION
### Motivation
- Aclarar en la documentación que la funcionalidad de impresión directa de etiquetas funciona mediante el navegador y la impresora configurada y no implementa un flujo Bluetooth propio dentro de la aplicación.

### Description
- Se añadió una nota al final de la sección "Impresión directa de etiquetas 10 × 10 cm en Windows" del `README.md` indicando que la impresión mantiene el flujo del navegador y la impresora configurada y que no incluye un flujo Bluetooth propio.

### Testing
- No se ejecutaron pruebas automatizadas para este cambio de documentación.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3940b14884832a9e3d65d017a1a7c8)