### PR TITLE
Fix print iframe sizing for 100×100mm labels and clarify README printing note

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,3 +276,5 @@ La pantalla de etiquetas imprime cada EAN-13 en una página física de 100 × 10
    ```
 
 Sin `--kiosk-printing`, los navegadores muestran obligatoriamente su diálogo de impresión. La aplicación genera el trabajo en un marco oculto y no abre una pestaña o ventana adicional.
+
+> Nota: la impresión de etiquetas se mantiene con el flujo del navegador y la impresora configurada; no incluye un flujo Bluetooth propio dentro de la aplicación.

--- a/frontend/src/pages/items/ItemsDownloadPage.jsx
+++ b/frontend/src/pages/items/ItemsDownloadPage.jsx
@@ -201,9 +201,12 @@ function printHtmlInHiddenFrame(html) {
     const printFrame = document.createElement('iframe');
     printFrame.setAttribute('aria-hidden', 'true');
     printFrame.style.position = 'fixed';
-    printFrame.style.width = '0';
-    printFrame.style.height = '0';
+    printFrame.style.left = '-10000px';
+    printFrame.style.top = '0';
+    printFrame.style.width = '100mm';
+    printFrame.style.height = '100mm';
     printFrame.style.border = '0';
+    printFrame.style.opacity = '0';
 
     const removeFrame = () => {
       if (printFrame.parentNode) {


### PR DESCRIPTION
### Motivation
- Prevent printing issues caused by a zero-dimension hidden iframe so label pages render at the intended 100×100 mm physical size when using kiosk printing.
- Make explicit in the documentation that label printing relies on the browser/printer flow and does not include an app-level Bluetooth printing flow.

### Description
- Update `frontend/src/pages/items/ItemsDownloadPage.jsx` to position the print iframe off-screen (`left: -10000px`), set explicit dimensions (`width: 100mm`, `height: 100mm`) and `opacity: 0` so printed content uses correct physical page size while remaining invisible to the user.
- Replace the previous zero-size iframe styling with the new off-screen sizing approach and keep `aria-hidden` and cleanup logic to remove the iframe after printing.
- Append a clarifying note to `README.md` stating that label printing is handled via the browser/printer flow and that there is no built-in Bluetooth printing flow.

### Testing
- Ran frontend linting with `npm run lint` and unit tests with `npm test`, and both completed successfully.
- Performed a frontend build with `npm run build` to verify no compilation errors and the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3940b14884832a9e3d65d017a1a7c8)