### PR TITLE
Remove Bluetooth label printing UI

### DIFF
--- a/frontend/src/pages/items/ItemsDownloadPage.jsx
+++ b/frontend/src/pages/items/ItemsDownloadPage.jsx
@@ -306,10 +306,8 @@ export default function ItemsDownloadPage() {
   const [colorFilterOptions, setColorFilterOptions] = useState(DEFAULT_COLOR_FILTER_OPTIONS);
   const [filters, setFilters] = useState({ search: '', groupId: '', gender: '', size: '', color: '' });
   const [printing, setPrinting] = useState(false);
-  const [bluetoothPrinting, setBluetoothPrinting] = useState(false);
   const [selectedItemsForPrint, setSelectedItemsForPrint] = useState({});
   const [includeSkuInPdf, setIncludeSkuInPdf] = useState(false);
-  const bluetoothUnavailableReason = getWebBluetoothUnavailableReason();
 
   const totalPages = Math.max(1, Math.ceil(total / pageSize));
 
@@ -561,23 +559,6 @@ export default function ItemsDownloadPage() {
     handlePrintLabels100x100(selectedItemsList);
   }, [handlePrintLabels100x100, selectedItemsList]);
 
-  const handlePrintSelectedLabelsWithBluetooth = useCallback(async () => {
-    if (bluetoothPrinting || printing) return;
-    setBluetoothPrinting(true);
-    setError(null);
-    try {
-      const collectedItems = [...selectedItemsList];
-      if (collectedItems.length === 0) {
-        throw new Error('Seleccioná al menos un artículo para imprimir por Bluetooth.');
-      }
-      await printLabelsWithBluetooth(collectedItems);
-    } catch (err) {
-      setError(err);
-    } finally {
-      setBluetoothPrinting(false);
-    }
-  }, [bluetoothPrinting, printing, selectedItemsList]);
-
   const handlePrintSingleLabel = useCallback(
     item => {
       if (!item?.id) return;
@@ -706,7 +687,7 @@ export default function ItemsDownloadPage() {
         <div>
           <h2>Descarga de artículos</h2>
           <p style={{ color: '#475569', marginTop: '-0.4rem' }}>
-            Seleccioná artículos para descargar el PDF o imprimir etiquetas de código de barras de 10 × 10 cm, incluyendo impresoras Bluetooth compatibles desde el celular.
+            Seleccioná artículos para descargar el PDF o imprimir etiquetas de código de barras de 10 × 10 cm.
           </p>
         </div>
         <div>
@@ -732,7 +713,7 @@ export default function ItemsDownloadPage() {
               type="button"
               className="secondary-button"
               onClick={handleDownloadSelectedPdf}
-              disabled={printing || bluetoothPrinting || selectedItemsList.length === 0}
+              disabled={printing || selectedItemsList.length === 0}
               title={selectedItemsList.length === 0 ? 'Seleccioná artículos para habilitar la descarga.' : undefined}
             >
               {printing ? 'Preparando impresión…' : 'Descargar PDF'}
@@ -741,25 +722,11 @@ export default function ItemsDownloadPage() {
               type="button"
               className="secondary-button"
               onClick={handlePrintSelectedLabels}
-              disabled={printing || bluetoothPrinting || selectedItemsList.length === 0}
+              disabled={printing || selectedItemsList.length === 0}
               title={selectedItemsList.length === 0 ? 'Seleccioná artículos para habilitar la impresión.' : 'Imprime una etiqueta de 10 × 10 cm por cada artículo seleccionado.'}
             >
               {printing ? 'Preparando impresión…' : 'Imprimir etiquetas 10 × 10'}
             </button>
-            <button
-              type="button"
-              className="secondary-button"
-              onClick={handlePrintSelectedLabelsWithBluetooth}
-              disabled={printing || bluetoothPrinting || selectedItemsList.length === 0 || Boolean(bluetoothUnavailableReason)}
-              title={bluetoothUnavailableReason || 'Conecta con una impresora Bluetooth BLE desde el celular y envía etiquetas TSPL de 10 × 10 cm.'}
-            >
-              {bluetoothPrinting ? 'Enviando por Bluetooth…' : 'Imprimir por Bluetooth'}
-            </button>
-            {bluetoothUnavailableReason && (
-              <small style={{ color: '#b45309', maxWidth: '18rem' }}>
-                {bluetoothUnavailableReason}
-              </small>
-            )}
           </div>
         </div>
         <form className="form-grid" style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))' }}>
@@ -855,7 +822,7 @@ export default function ItemsDownloadPage() {
               Seleccionados: <strong>{selectedItemsList.length}</strong>
             </span>
             <p style={{ margin: '0.15rem 0 0', color: '#64748b', fontSize: '0.78rem' }}>
-              Podés marcar uno o varios artículos para descargar el PDF, imprimir normal o enviar etiquetas por Bluetooth desde Chrome/Edge en Android.
+              Podés marcar uno o varios artículos para descargar el PDF o imprimir etiquetas de forma normal.
             </p>
           </div>
           <div className="inline-actions">


### PR DESCRIPTION
### Motivation
- Revertir el flujo de impresión por Bluetooth que se había agregado porque provoca problemas en la pantalla (recupera en blanco) y se necesita volver al comportamiento previo estable.

### Description
- Eliminé el estado y la dependencia de impresión por Bluetooth (`bluetoothPrinting`, `bluetoothUnavailableReason`) en `frontend/src/pages/items/ItemsDownloadPage.jsx`.
- Eliminé el manejador `handlePrintSelectedLabelsWithBluetooth` y el botón/auxiliares de UI que exponían el flujo Bluetooth en la página de descarga/impresión de artículos.
- Restauré los textos de ayuda y la lógica de deshabilitado de botones para depender únicamente de `printing` y de la selección de artículos, y limpié pequeños duplicados en el código del marco de impresión.

### Testing
- Ejecuté `npm run build` en `frontend` y la compilación de producción con Vite completó correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3956623ae4832a8a4fa35cb41bffea)