### PR TITLE
Ocultar botón 'Descargar PDF Etiqueta 10x10'

### DIFF
--- a/frontend/src/pages/items/ItemsDownloadPage.jsx
+++ b/frontend/src/pages/items/ItemsDownloadPage.jsx
@@ -756,15 +756,6 @@ export default function ItemsDownloadPage() {
             <button
               type="button"
               className="secondary-button"
-              onClick={handleDownloadSelectedLabelsPdf}
-              disabled={printing || selectedItemsList.length === 0}
-              title={selectedItemsList.length === 0 ? 'Seleccioná artículos para habilitar la descarga.' : 'Descarga una etiqueta de 10 × 10 cm por página para cada artículo seleccionado.'}
-            >
-              {printing ? 'Preparando impresión…' : 'Descargar PDF Etiqueta 10x10'}
-            </button>
-            <button
-              type="button"
-              className="secondary-button"
               onClick={handlePrintSelectedLabels}
               disabled={printing || selectedItemsList.length === 0}
               title={selectedItemsList.length === 0 ? 'Seleccioná artículos para habilitar la impresión.' : 'Imprime una etiqueta de 10 × 10 cm por cada artículo seleccionado.'}


### PR DESCRIPTION
### Motivation
- Ocultar la opción de descarga de PDF de etiquetas 10×10 en la página de descarga de artículos para evitar que los usuarios instiguen esa acción mientras se mantienen disponibles la descarga de lista y la impresión de etiquetas.

### Description
- Eliminado el botón JSX que llamaba a `handleDownloadSelectedLabelsPdf` en `frontend/src/pages/items/ItemsDownloadPage.jsx`, conservando `Descargar Lista PDF` y `Imprimir etiquetas 10 × 10` sin cambios.

### Testing
- Ejecutado `npm run build` en `frontend` y completado con éxito.
- Ejecutado `npm run lint` y completado con éxito.
- Ejecutado `git diff --check` sin errores.
- Intento automatizado de captura con `playwright` falló debido a que `playwright` no está instalado (`MODULE_NOT_FOUND`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a397e297de8832a82e0a31703e8d3ea)