### PR TITLE
Soporta variantes de SKU (con/sin ceros) al derivar desde EAN-13 interno

### DIFF
--- a/backend/src/routes/stock.js
+++ b/backend/src/routes/stock.js
@@ -39,6 +39,15 @@ function uniqueValues(values) {
   return Array.from(new Set(values.filter(Boolean)));
 }
 
+function buildSkuLookupVariants(value) {
+  const digits = String(value || '').replace(/\D/g, '');
+  if (!digits) {
+    return [];
+  }
+  const trimmed = digits.replace(/^0+(?=\d)/, '');
+  return uniqueValues([digits, trimmed]);
+}
+
 function deriveSkusFromInternalEan13(value) {
   const rawDigits = String(value || '').replace(/\D/g, '');
   const eanCandidates = uniqueValues([
@@ -59,12 +68,12 @@ function deriveSkusFromInternalEan13(value) {
 
     // Formato actual: 04 + SKU de 6 dígitos + 0000 + verificador.
     if (digits.slice(8, 12) === '0000') {
-      skuCandidates.push(digits.slice(2, 8));
+      skuCandidates.push(...buildSkuLookupVariants(digits.slice(2, 8)));
     }
     // Formato legado: 04 + SKU llevado a 7 dígitos + 000 + verificador.
     // Como el SKU guardado es de 6 dígitos, se toma el final del segmento.
     if (digits.slice(9, 12) === '000') {
-      skuCandidates.push(digits.slice(2, 9).slice(-6));
+      skuCandidates.push(...buildSkuLookupVariants(digits.slice(2, 9).slice(-6)));
     }
   });
 


### PR DESCRIPTION
### Motivation
- Corregir la resolución de SKU derivada de EAN-13 internos para que cuando se obtenga algo como `000027` también pruebe `27`, evitando que el escaneo falle o resuelva al artículo equivocado si el SKU está guardado sin ceros a la izquierda.

### Description
- Añadí la función `buildSkuLookupVariants` y la reemplacé en `deriveSkusFromInternalEan13` para generar y probar ambas variantes (zero-padded y trimmed) tanto en el formato actual como en el legado del EAN-13.

### Testing
- Ejecuté `npm test`, que se completó correctamente pero no hay pruebas automatizadas definidas (`No hay pruebas automatizadas definidas`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a46be30dbb4832a85df6640ac705f6e)