### PR TITLE
Handle leading-zero SKU variants for EAN-13 lookup and prefer current internal EAN in scanner

### DIFF
--- a/backend/src/routes/stock.js
+++ b/backend/src/routes/stock.js
@@ -39,6 +39,15 @@ function uniqueValues(values) {
   return Array.from(new Set(values.filter(Boolean)));
 }
 
+function buildSkuLookupVariants(value) {
+  const digits = String(value || '').replace(/\D/g, '');
+  if (!digits) {
+    return [];
+  }
+  const trimmed = digits.replace(/^0+(?=\d)/, '');
+  return uniqueValues([digits, trimmed]);
+}
+
 function deriveSkusFromInternalEan13(value) {
   const rawDigits = String(value || '').replace(/\D/g, '');
   const eanCandidates = uniqueValues([
@@ -59,12 +68,12 @@ function deriveSkusFromInternalEan13(value) {
 
     // Formato actual: 04 + SKU de 6 dígitos + 0000 + verificador.
     if (digits.slice(8, 12) === '0000') {
-      skuCandidates.push(digits.slice(2, 8));
+      skuCandidates.push(...buildSkuLookupVariants(digits.slice(2, 8)));
     }
     // Formato legado: 04 + SKU llevado a 7 dígitos + 000 + verificador.
     // Como el SKU guardado es de 6 dígitos, se toma el final del segmento.
     if (digits.slice(9, 12) === '000') {
-      skuCandidates.push(digits.slice(2, 9).slice(-6));
+      skuCandidates.push(...buildSkuLookupVariants(digits.slice(2, 9).slice(-6)));
     }
   });
 

--- a/frontend/src/pages/items/BarcodeReceptionPage.jsx
+++ b/frontend/src/pages/items/BarcodeReceptionPage.jsx
@@ -259,8 +259,10 @@ export default function BarcodeReceptionPage() {
       const returnedBarcodes = (Array.isArray(item.internalBarcodes) ? item.internalBarcodes : [])
         .map(value => normalizeBarcodeValue(value).toLowerCase());
       if (scannedValues.includes(code) || scannedValues.includes(sku)) return 4;
-      if (scannedValues.includes(legacyInternalBarcode)) return 3;
-      if (scannedValues.includes(currentInternalBarcode)) return 2;
+      // El formato actual debe ganar sobre el legado: un mismo EAN puede
+      // representar SKU 27 en el formato actual y SKU 270 en el legacy.
+      if (scannedValues.includes(currentInternalBarcode)) return 3;
+      if (scannedValues.includes(legacyInternalBarcode)) return 2;
       if (returnedBarcodes.some(barcodeValue => scannedValues.includes(barcodeValue))) return 1;
       return 0;
     };


### PR DESCRIPTION
### Motivation
- Fix ambiguity when extracting SKU values from internal EAN-13 codes that may include leading zeros or be read as 12-digit UPCs. 
- Ensure the scanner prefers the current internal EAN format over the legacy format when a single barcode could map to different SKUs. 
- Improve robustness of SKU lookup by returning both raw and trimmed-digit variants for matching.

### Description
- Added `buildSkuLookupVariants` which returns numeric-only SKU lookup variants including a version with leading zeros trimmed. 
- Updated `deriveSkusFromInternalEan13` to use `buildSkuLookupVariants` when pushing SKU candidates for both current and legacy EAN formats. 
- Adjusted frontend barcode matching in `BarcodeReceptionPage.jsx` to score `currentInternalBarcode` higher than `legacyInternalBarcode` so the current format wins ties, and added a clarifying comment.

### Testing
- Ran the project's automated test suite (`npm test`) and linting (`npm run lint`) and observed all tests and linters passing. 
- Executed frontend component tests (`yarn test`) and they passed without regressions. 
- Verified relevant unit tests covering EAN/SKU derivation and barcode matching logic succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a46be30dbb4832a85df6640ac705f6e)