### PR TITLE
Restore original button colors

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1014,22 +1014,6 @@ th {
   color: #64748b;
 }
 
-.secondary-button {
-  background-color: #64748b;
-}
-
-.secondary-button:hover:not(:disabled) {
-  background-color: #475569;
-}
-
-.danger-button {
-  background-color: #dc2626;
-}
-
-.danger-button:hover:not(:disabled) {
-  background-color: #b91c1c;
-}
-
 .table-responsive {
   overflow-x: auto;
 }


### PR DESCRIPTION
### Motivation
- Una adición reciente de estilos (estilos de Shopify) añadió reglas duplicadas que sobrescribían los colores originales de los botones globales, provocando un cambio de color inesperado en la UI.

### Description
- Eliminé las reglas duplicadas que redefinían `.secondary-button` y `.danger-button` al final de `frontend/src/index.css` para restaurar los estilos originales.
- Conservé los estilos previos donde el botón secundario es transparente/azul y el botón de peligro usa el rojo claro con su hover más oscuro.
- El único archivo modificado es `frontend/src/index.css` y no se añadieron nuevas dependencias ni cambios funcionales en JS.

### Testing
- Ejecuté `npm run build` en `frontend` y la compilación de producción completó correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5f69ef626c832a94c8f70abb143aa2)