### PR TITLE
Add Shopify inventory webhook handling and mapping for inventoryItemId / shopifyLocationId

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -17,10 +17,29 @@ const reportsRoutes = require('./routes/reports');
 const rolesRoutes = require('./routes/roles');
 const preferencesRoutes = require('./routes/preferences');
 const shopifyRoutes = require('./routes/shopify');
+const { verifyShopifyWebhook, parseWebhookBody, applyInventoryLevelUpdate } = require('./services/shopifyWebhookService');
 
 const app = express();
 
 app.use(cors());
+
+app.post('/api/shopify/webhooks/inventory-levels-update', express.raw({ type: 'application/json', limit: '2mb' }), async (req, res, next) => {
+  try {
+    const verification = verifyShopifyWebhook(req.body, req.get('X-Shopify-Hmac-Sha256'));
+    if (!verification.ok) {
+      throw new HttpError(401, verification.reason);
+    }
+    const payload = parseWebhookBody(req.body);
+    if (!payload) {
+      throw new HttpError(400, 'Payload Shopify inválido.');
+    }
+    const result = await applyInventoryLevelUpdate(payload);
+    res.json(result);
+  } catch (error) {
+    next(error);
+  }
+});
+
 app.use(express.json({ limit: '75mb', strict: false }));
 app.use(morgan('dev'));
 app.use('/uploads', express.static(path.join(__dirname, '..', 'uploads')));

--- a/backend/src/config.js
+++ b/backend/src/config.js
@@ -41,6 +41,7 @@ const config = {
     apiVersion: process.env.SHOPIFY_API_VERSION || '2026-07',
     dryRun: normalizeBoolean(process.env.SHOPIFY_DRY_RUN) ?? true,
     defaultLocationId: process.env.SHOPIFY_DEFAULT_LOCATION_ID || '',
+    inventoryWebhookSyncEnabled: normalizeBoolean(process.env.SHOPIFY_INVENTORY_WEBHOOK_SYNC_ENABLED) ?? false,
     publicBackendUrl: (process.env.PUBLIC_BACKEND_URL || process.env.BACKEND_PUBLIC_URL || '').replace(/\/$/, '')
   }
 };

--- a/backend/src/models/Item.js
+++ b/backend/src/models/Item.js
@@ -37,6 +37,7 @@ const itemSchema = new Schema(
     shopify: {
       productId: { type: String, default: null, trim: true },
       variantId: { type: String, default: null, trim: true },
+      inventoryItemId: { type: String, default: null, trim: true, index: true },
       handle: { type: String, default: null, trim: true },
       status: { type: String, enum: ['draft', 'active', 'archived', 'deleted'], default: 'draft' },
       lastSyncedAt: { type: Date, default: null },

--- a/backend/src/models/Location.js
+++ b/backend/src/models/Location.js
@@ -8,6 +8,7 @@ const locationSchema = new Schema(
     type: { type: String, enum: LOCATION_TYPES, default: 'warehouse' },
     description: { type: String, default: '' },
     contactInfo: { type: String, default: '' },
+    shopifyLocationId: { type: String, default: null, trim: true, index: true },
     status: { type: String, enum: ['active', 'inactive'], default: 'active' }
   },
   {

--- a/backend/src/routes/locations.js
+++ b/backend/src/routes/locations.js
@@ -18,6 +18,7 @@ function serializeLocation(location) {
     type: location.type,
     description: location.description || '',
     contactInfo: location.contactInfo || '',
+    shopifyLocationId: location.shopifyLocationId || '',
     status: location.status
   };
 }
@@ -58,7 +59,7 @@ router.post(
   '/',
   requirePermission('items.write'),
   asyncHandler(async (req, res) => {
-    const { name, description, contactInfo, status, type } = req.body || {};
+    const { name, description, contactInfo, shopifyLocationId, status, type } = req.body || {};
     if (!name || typeof name !== 'string' || !name.trim()) {
       throw new HttpError(400, 'El nombre es obligatorio');
     }
@@ -67,6 +68,7 @@ router.post(
       type: ensureValidType(type),
       description: sanitizeOptionalString(description),
       contactInfo: sanitizeOptionalString(contactInfo),
+      shopifyLocationId: sanitizeOptionalString(shopifyLocationId) || null,
       status: status === 'inactive' ? 'inactive' : 'active'
     });
     res.status(201).json(serializeLocation(location));
@@ -82,7 +84,7 @@ router.put(
     if (!location) {
       throw new HttpError(404, 'Ubicación no encontrada');
     }
-    const { name, description, contactInfo, status, type } = req.body || {};
+    const { name, description, contactInfo, shopifyLocationId, status, type } = req.body || {};
     if (name !== undefined) {
       if (typeof name !== 'string' || !name.trim()) {
         throw new HttpError(400, 'El nombre es obligatorio');
@@ -97,6 +99,9 @@ router.put(
     }
     if (contactInfo !== undefined) {
       location.contactInfo = sanitizeOptionalString(contactInfo);
+    }
+    if (shopifyLocationId !== undefined) {
+      location.shopifyLocationId = sanitizeOptionalString(shopifyLocationId) || null;
     }
     if (status !== undefined) {
       if (!['active', 'inactive'].includes(status)) {

--- a/backend/src/routes/shopify.js
+++ b/backend/src/routes/shopify.js
@@ -126,6 +126,7 @@ function serializeShopifyItem(item, locations = []) {
     shopify: {
       productId: item.shopify?.productId || null,
       variantId: item.shopify?.variantId || null,
+      inventoryItemId: item.shopify?.inventoryItemId || null,
       handle: item.shopify?.handle || null,
       status: getShopifyStatus(item),
       lastSyncedAt: item.shopify?.lastSyncedAt || null,
@@ -236,12 +237,14 @@ router.post(
         : {
             productId: item.shopify?.productId || `local-${item.id}`,
             variantId: item.shopify?.variantId || `variant-${item.id}`,
+            inventoryItemId: item.shopify?.inventoryItemId || `inventory-${item.id}`,
             handle: item.description.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '').replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '').slice(0, 80) || item.code,
             status: nextStatus
           };
       setShopifyFields(item, {
         productId: syncedProduct.productId,
         variantId: syncedProduct.variantId,
+        inventoryItemId: syncedProduct.inventoryItemId || item.shopify?.inventoryItemId || null,
         handle: syncedProduct.handle,
         status: syncedProduct.status,
         lastSyncedAt: now,

--- a/backend/src/services/shopifyProductService.js
+++ b/backend/src/services/shopifyProductService.js
@@ -73,7 +73,7 @@ async function updateDefaultVariant(productId, variantId, payload) {
         productVariants {
           id
           price
-          inventoryItem { sku }
+          inventoryItem { id sku }
         }
         userErrors { field message }
       }
@@ -94,7 +94,7 @@ async function createShopifyProduct(payload, status) {
           handle
           status
           variants(first: 1) {
-            nodes { id }
+            nodes { id inventoryItem { id } }
           }
         }
         userErrors { field message }
@@ -109,11 +109,13 @@ async function createShopifyProduct(payload, status) {
   if (!product?.id) {
     throw new HttpError(502, 'Shopify no devolvió el producto creado.');
   }
-  const variantId = product.variants?.nodes?.[0]?.id || null;
+  const variantNode = product.variants?.nodes?.[0] || null;
+  const variantId = variantNode?.id || null;
   const updatedVariant = await updateDefaultVariant(product.id, variantId, payload);
   return {
     productId: product.id,
     variantId: updatedVariant?.id || variantId,
+    inventoryItemId: updatedVariant?.inventoryItem?.id || variantNode?.inventoryItem?.id || null,
     handle: product.handle || null,
     status: String(product.status || status || 'draft').toLowerCase()
   };
@@ -159,7 +161,7 @@ async function updateShopifyProduct(productId, payload, status) {
           handle
           status
           variants(first: 1) {
-            nodes { id }
+            nodes { id inventoryItem { id } }
           }
         }
         userErrors { field message }
@@ -173,12 +175,14 @@ async function updateShopifyProduct(productId, payload, status) {
   if (!product?.id) {
     throw new HttpError(502, 'Shopify no devolvió el producto actualizado.');
   }
-  const variantId = product.variants?.nodes?.[0]?.id || null;
+  const variantNode = product.variants?.nodes?.[0] || null;
+  const variantId = variantNode?.id || null;
   const updatedVariant = await updateDefaultVariant(product.id, variantId, payload);
   await appendProductMediaIfEmpty(product.id, payload.media);
   return {
     productId: product.id,
     variantId: updatedVariant?.id || variantId,
+    inventoryItemId: updatedVariant?.inventoryItem?.id || variantNode?.inventoryItem?.id || null,
     handle: product.handle || null,
     status: String(product.status || status || 'draft').toLowerCase()
   };

--- a/backend/src/services/shopifyWebhookService.js
+++ b/backend/src/services/shopifyWebhookService.js
@@ -1,0 +1,104 @@
+const crypto = require('crypto');
+const Item = require('../models/Item');
+const Location = require('../models/Location');
+const { recordAuditEvent } = require('./auditService');
+const config = require('../config');
+
+function shopifyGid(resource, id) {
+  const value = String(id || '').trim();
+  if (!value) return null;
+  if (value.startsWith('gid://shopify/')) return value;
+  return /^\d+$/.test(value) ? `gid://shopify/${resource}/${value}` : value;
+}
+
+function getIdCandidates(resource, value) {
+  const raw = String(value || '').trim();
+  if (!raw) return [];
+  const candidates = new Set([raw]);
+  const numeric = raw.match(/\/(\d+)$/)?.[1] || (/^\d+$/.test(raw) ? raw : null);
+  if (numeric) {
+    candidates.add(numeric);
+    candidates.add(`gid://shopify/${resource}/${numeric}`);
+  }
+  return Array.from(candidates);
+}
+
+function verifyShopifyWebhook(rawBody, hmacHeader) {
+  const secret = config.shopify.clientSecret;
+  if (!secret) return { ok: false, reason: 'Falta SHOPIFY_CLIENT_SECRET para validar webhooks.' };
+  if (!hmacHeader) return { ok: false, reason: 'Falta X-Shopify-Hmac-Sha256.' };
+  const digest = crypto.createHmac('sha256', secret).update(rawBody).digest('base64');
+  const expected = Buffer.from(digest, 'utf8');
+  const received = Buffer.from(String(hmacHeader), 'utf8');
+  if (expected.length !== received.length || !crypto.timingSafeEqual(expected, received)) {
+    return { ok: false, reason: 'Firma HMAC inválida.' };
+  }
+  return { ok: true };
+}
+
+function parseWebhookBody(rawBody) {
+  try {
+    return JSON.parse(rawBody.toString('utf8'));
+  } catch (error) {
+    return null;
+  }
+}
+
+async function applyInventoryLevelUpdate(payload) {
+  if (!config.shopify.inventoryWebhookSyncEnabled) {
+    return {
+      status: 'disabled',
+      reason: 'La sincronización automática de stock desde webhooks Shopify está deshabilitada.'
+    };
+  }
+
+  const inventoryItemCandidates = getIdCandidates('InventoryItem', payload.inventory_item_id || payload.inventoryItemId);
+  const locationCandidates = getIdCandidates('Location', payload.location_id || payload.locationId);
+  const available = Number(payload.available);
+  if (!Number.isInteger(available) || available < 0) {
+    return { status: 'ignored', reason: 'El webhook no incluye stock disponible válido.' };
+  }
+  if (inventoryItemCandidates.length === 0 || locationCandidates.length === 0) {
+    return { status: 'ignored', reason: 'El webhook no incluye IDs de inventario y ubicación.' };
+  }
+
+  const [item, location] = await Promise.all([
+    Item.findOne({ deletedAt: null, 'shopify.inventoryItemId': { $in: inventoryItemCandidates } }),
+    Location.findOne({ shopifyLocationId: { $in: locationCandidates } })
+  ]);
+
+  if (!item || !location) {
+    return {
+      status: 'unmapped',
+      reason: !item ? 'Inventario Shopify sin artículo mapeado.' : 'Ubicación Shopify sin ubicación mapeada.',
+      inventoryItemId: shopifyGid('InventoryItem', payload.inventory_item_id || payload.inventoryItemId),
+      locationId: shopifyGid('Location', payload.location_id || payload.locationId)
+    };
+  }
+
+  if (!item.stock || !(item.stock instanceof Map)) {
+    item.stock = new Map(Object.entries(item.stock || {}));
+  }
+  const locationId = location.id;
+  if (available === 0) {
+    item.stock.delete(locationId);
+  } else {
+    item.stock.set(locationId, { boxes: 0, units: available });
+  }
+  item.shopify.lastSyncedAt = new Date();
+  item.shopify.lastAction = 'webhook-inventory-levels-update';
+  item.shopify.lastError = null;
+  item.markModified('stock');
+  await item.save();
+
+  await recordAuditEvent({
+    action: 'Shopify',
+    request: `Stock actualizado por webhook Shopify para ${item.code}`,
+    user: 'Shopify webhook',
+    details: { itemId: item.id, locationId, available, shopifyPayload: payload }
+  });
+
+  return { status: 'updated', itemId: item.id, locationId, available };
+}
+
+module.exports = { verifyShopifyWebhook, parseWebhookBody, applyInventoryLevelUpdate };

--- a/docs/shopify-setup.md
+++ b/docs/shopify-setup.md
@@ -31,6 +31,7 @@ SHOPIFY_ADMIN_ACCESS_TOKEN=
 SHOPIFY_API_VERSION=2026-07
 SHOPIFY_DRY_RUN=true
 SHOPIFY_DEFAULT_LOCATION_ID=
+SHOPIFY_INVENTORY_WEBHOOK_SYNC_ENABLED=false
 PUBLIC_BACKEND_URL=https://tu-dominio-o-ip
 ```
 
@@ -43,6 +44,7 @@ PUBLIC_BACKEND_URL=https://tu-dominio-o-ip
 | `SHOPIFY_API_VERSION` | No | Versión de Admin API. Por defecto: `2026-07`. |
 | `SHOPIFY_DRY_RUN` | No | Si está en `true`, el sistema prepara payloads y registra estado local sin llamar a Shopify. |
 | `SHOPIFY_DEFAULT_LOCATION_ID` | No | ID de ubicación Shopify para sincronizar inventario cuando se defina el mapeo. |
+| `SHOPIFY_INVENTORY_WEBHOOK_SYNC_ENABLED` | No | Habilita la aplicación automática de webhooks `inventory_levels/update` sobre el stock local. Por seguridad queda en `false` por defecto. |
 | `PUBLIC_BACKEND_URL` / `BACKEND_PUBLIC_URL` | Recomendado para imágenes | URL pública desde donde Shopify puede descargar imágenes guardadas en `uploads/items`. Debe apuntar al backend y ser accesible desde internet. |
 
 > Seguridad: el secreto y cualquier token solo deben existir en el backend. Nunca deben exponerse en React, commits, capturas ni logs.
@@ -68,3 +70,17 @@ Con esas credenciales, el backend ya puede obtener un token por `client_credenti
 - actualizar variante/precio/SKU;
 - enviar imágenes públicas del artículo como media del producto;
 - mapear inventario por ubicación.
+
+## 5. Mapeo de ubicaciones y baja automática por ventas
+
+Para que una venta o cualquier ajuste de inventario en Shopify impacte el stock local sin intervención del usuario, primero activar explícitamente `SHOPIFY_INVENTORY_WEBHOOK_SYNC_ENABLED=true` en el backend. Por seguridad, si la variable queda en `false`, el webhook responde correctamente pero no modifica stock local.
+
+1. En el sistema, abrir **Ubicaciones** y cargar en cada depósito interno el **ID ubicación Shopify** correspondiente. Puede guardarse como número (`123456789`) o como GID (`gid://shopify/Location/123456789`).
+2. Sincronizar los artículos desde la pantalla **Shopify**. La sincronización guarda el `InventoryItem` de la variante Shopify en cada artículo local.
+3. En Shopify, crear un webhook Admin API para el topic `inventory_levels/update` apuntando a:
+
+```text
+https://TU_BACKEND_PUBLICO/api/shopify/webhooks/inventory-levels-update
+```
+
+El backend valida la firma `X-Shopify-Hmac-Sha256` con `SHOPIFY_CLIENT_SECRET`. Cuando llega el webhook, busca el artículo por `inventory_item_id`, busca la ubicación por `location_id` y reemplaza el stock de esa ubicación con el `available` recibido desde Shopify. Si Shopify informa `0`, la ubicación se elimina del mapa de stock del artículo.

--- a/frontend/src/pages/locations/LocationsPage.jsx
+++ b/frontend/src/pages/locations/LocationsPage.jsx
@@ -9,6 +9,7 @@ const INITIAL_FORM_STATE = {
   type: 'warehouse',
   description: '',
   contactInfo: '',
+  shopifyLocationId: '',
   status: 'active'
 };
 
@@ -53,6 +54,7 @@ export default function LocationsPage() {
       type: normalizedType,
       description: location.description || '',
       contactInfo: location.contactInfo || '',
+      shopifyLocationId: location.shopifyLocationId || '',
       status: location.status === 'inactive' ? 'inactive' : 'active'
     };
   };
@@ -118,6 +120,7 @@ export default function LocationsPage() {
       type: location.type,
       description: location.description,
       contactInfo: location.contactInfo,
+      shopifyLocationId: location.shopifyLocationId || '',
       status: location.status
     });
     setSuccessMessage('');
@@ -239,6 +242,7 @@ export default function LocationsPage() {
                 <th>Descripción</th>
                 <th>Contacto</th>
                 <th>Estado</th>
+                <th>Shopify</th>
                 {canWrite && <th>Acciones</th>}
               </tr>
             </thead>
@@ -256,6 +260,7 @@ export default function LocationsPage() {
                       {location.status}
                     </span>
                   </td>
+                  <td>{location.shopifyLocationId || '-'}</td>
                   {canWrite && (
                     <td>
                       <div className="inline-actions">
@@ -277,7 +282,7 @@ export default function LocationsPage() {
               ))}
               {filteredLocations.length === 0 && (
                 <tr>
-                  <td colSpan={canWrite ? 6 : 5} style={{ textAlign: 'center', padding: '1.5rem 0' }}>
+                  <td colSpan={canWrite ? 7 : 6} style={{ textAlign: 'center', padding: '1.5rem 0' }}>
                     No hay ubicaciones registradas con el filtro seleccionado.
                   </td>
                 </tr>
@@ -333,6 +338,16 @@ export default function LocationsPage() {
                 name="description"
                 value={formValues.description}
                 onChange={handleFormChange}
+              />
+            </div>
+            <div className="input-group">
+              <label htmlFor="locationShopify">ID ubicación Shopify</label>
+              <input
+                id="locationShopify"
+                name="shopifyLocationId"
+                value={formValues.shopifyLocationId}
+                onChange={handleFormChange}
+                placeholder="Ej: 123456789 o gid://shopify/Location/123456789"
               />
             </div>
             <div className="input-group">


### PR DESCRIPTION
### Motivation

- Add automatic handling of Shopify `inventory_levels/update` webhooks to reflect stock changes in the local system when locations and items are mapped.  
- Persist Shopify identifiers for variants/inventory items and locations to allow two-way mapping and reliable updates.  
- Provide a safe opt-in switch and docs so webhook-driven stock updates are disabled by default for security.

### Description

- Added a new webhook endpoint `POST /api/shopify/webhooks/inventory-levels-update` that validates the `X-Shopify-Hmac-Sha256` header and delegates processing to `services/shopifyWebhookService.js`.  
- Implemented `services/shopifyWebhookService.js` which verifies HMAC signatures, parses webhook bodies, looks up `Item` by `shopify.inventoryItemId` and `Location` by `shopifyLocationId`, updates the local `stock` map, records an audit event, and returns structured status responses.  
- Extended `Item` model with `shopify.inventoryItemId` (indexed) and `Location` model with `shopifyLocationId` (indexed), and updated the shopify product sync logic in `services/shopifyProductService.js` and `/routes/shopify.js` to capture and persist `inventoryItemId`.  
- Exposed `shopifyLocationId` in the locations API and UI by updating `routes/locations.js`, the frontend `LocationsPage.jsx` form and table to edit/display the Shopify location ID, and ensured CRUD operations persist the new field.  
- Added a configuration flag `SHOPIFY_INVENTORY_WEBHOOK_SYNC_ENABLED` in `config.js` and documented its usage in `docs/shopify-setup.md`, defaulting to `false` for safety.

### Testing

- Ran backend test suite via `npm test` and the tests completed successfully.  
- Built the frontend via `npm run build` to validate compilation and the UI changes, and the build succeeded.  
- Executed automated webhook smoke tests against the new endpoint (signed payloads) to verify HMAC validation and response flows, and those tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a625c94546c832a9638d43c18f33bae)