### PR TITLE
Enable Shopify inventory webhook sync by default and show Shopify mapping/current locations in UI

### DIFF
--- a/backend/src/config.js
+++ b/backend/src/config.js
@@ -41,7 +41,7 @@ const config = {
     apiVersion: process.env.SHOPIFY_API_VERSION || '2026-07',
     dryRun: normalizeBoolean(process.env.SHOPIFY_DRY_RUN) ?? true,
     defaultLocationId: process.env.SHOPIFY_DEFAULT_LOCATION_ID || '',
-    inventoryWebhookSyncEnabled: normalizeBoolean(process.env.SHOPIFY_INVENTORY_WEBHOOK_SYNC_ENABLED) ?? false,
+    inventoryWebhookSyncEnabled: normalizeBoolean(process.env.SHOPIFY_INVENTORY_WEBHOOK_SYNC_ENABLED) ?? true,
     publicBackendUrl: (process.env.PUBLIC_BACKEND_URL || process.env.BACKEND_PUBLIC_URL || '').replace(/\/$/, '')
   }
 };

--- a/docs/shopify-setup.md
+++ b/docs/shopify-setup.md
@@ -31,7 +31,7 @@ SHOPIFY_ADMIN_ACCESS_TOKEN=
 SHOPIFY_API_VERSION=2026-07
 SHOPIFY_DRY_RUN=true
 SHOPIFY_DEFAULT_LOCATION_ID=
-SHOPIFY_INVENTORY_WEBHOOK_SYNC_ENABLED=false
+SHOPIFY_INVENTORY_WEBHOOK_SYNC_ENABLED=true
 PUBLIC_BACKEND_URL=https://tu-dominio-o-ip
 ```
 
@@ -44,7 +44,7 @@ PUBLIC_BACKEND_URL=https://tu-dominio-o-ip
 | `SHOPIFY_API_VERSION` | No | Versión de Admin API. Por defecto: `2026-07`. |
 | `SHOPIFY_DRY_RUN` | No | Si está en `true`, el sistema prepara payloads y registra estado local sin llamar a Shopify. |
 | `SHOPIFY_DEFAULT_LOCATION_ID` | No | ID de ubicación Shopify para sincronizar inventario cuando se defina el mapeo. |
-| `SHOPIFY_INVENTORY_WEBHOOK_SYNC_ENABLED` | No | Habilita la aplicación automática de webhooks `inventory_levels/update` sobre el stock local. Por seguridad queda en `false` por defecto. |
+| `SHOPIFY_INVENTORY_WEBHOOK_SYNC_ENABLED` | No | Habilita la aplicación automática de webhooks `inventory_levels/update` sobre el stock local. Por defecto queda en `true`; usar `false` solo si se quiere recibir webhooks sin modificar stock local. |
 | `PUBLIC_BACKEND_URL` / `BACKEND_PUBLIC_URL` | Recomendado para imágenes | URL pública desde donde Shopify puede descargar imágenes guardadas en `uploads/items`. Debe apuntar al backend y ser accesible desde internet. |
 
 > Seguridad: el secreto y cualquier token solo deben existir en el backend. Nunca deben exponerse en React, commits, capturas ni logs.
@@ -73,7 +73,7 @@ Con esas credenciales, el backend ya puede obtener un token por `client_credenti
 
 ## 5. Mapeo de ubicaciones y baja automática por ventas
 
-Para que una venta o cualquier ajuste de inventario en Shopify impacte el stock local sin intervención del usuario, primero activar explícitamente `SHOPIFY_INVENTORY_WEBHOOK_SYNC_ENABLED=true` en el backend. Por seguridad, si la variable queda en `false`, el webhook responde correctamente pero no modifica stock local.
+Para que una venta o cualquier ajuste de inventario en Shopify impacte el stock local sin intervención del usuario, `SHOPIFY_INVENTORY_WEBHOOK_SYNC_ENABLED` queda habilitado por defecto en `true`. Si la variable se configura en `false`, el webhook responde correctamente pero no modifica stock local.
 
 1. En el sistema, abrir **Ubicaciones** y cargar en cada depósito interno el **ID ubicación Shopify** correspondiente. Puede guardarse como número (`123456789`) o como GID (`gid://shopify/Location/123456789`).
 2. Sincronizar los artículos desde la pantalla **Shopify**. La sincronización guarda el `InventoryItem` de la variante Shopify en cada artículo local.

--- a/frontend/src/pages/locations/LocationsPage.jsx
+++ b/frontend/src/pages/locations/LocationsPage.jsx
@@ -38,7 +38,6 @@ export default function LocationsPage() {
   const [saving, setSaving] = useState(false);
   const [deletingId, setDeletingId] = useState(null);
   const [successMessage, setSuccessMessage] = useState('');
-  const [showShopifyMapping, setShowShopifyMapping] = useState(false);
 
   const normalizeLocation = location => {
     const rawId = location.id || location._id;
@@ -71,13 +70,8 @@ export default function LocationsPage() {
           setLoading(false);
           return;
         }
-        const [locationsResponse, shopifyConfigResponse] = await Promise.all([
-          api.get('/locations'),
-          api.get('/shopify/config').catch(() => null)
-        ]);
+        const response = await api.get('/locations');
         if (!active) return;
-        setShowShopifyMapping(Boolean(shopifyConfigResponse?.inventoryWebhookSyncEnabled));
-        const response = locationsResponse;
         const normalized = Array.isArray(response)
           ? response
               .map(normalizeLocation)
@@ -99,7 +93,7 @@ export default function LocationsPage() {
     };
   }, [api, canRead]);
 
-  const locationsTableColSpan = 5 + (showShopifyMapping ? 1 : 0) + (canWrite ? 1 : 0);
+  const locationsTableColSpan = 6 + (canWrite ? 1 : 0);
 
   const filteredLocations = useMemo(() => {
     if (filterType === 'all') {
@@ -147,9 +141,6 @@ export default function LocationsPage() {
     setError(null);
     try {
       const payload = { ...formValues, name: trimmedName };
-      if (!showShopifyMapping) {
-        delete payload.shopifyLocationId;
-      }
       if (editingId) {
         const updated = await api.put(`/locations/${editingId}`, payload);
         const normalized = normalizeLocation(updated);
@@ -253,7 +244,7 @@ export default function LocationsPage() {
                 <th>Descripción</th>
                 <th>Contacto</th>
                 <th>Estado</th>
-                {showShopifyMapping && <th>Shopify</th>}
+                <th>Shopify</th>
                 {canWrite && <th>Acciones</th>}
               </tr>
             </thead>
@@ -271,7 +262,7 @@ export default function LocationsPage() {
                       {location.status}
                     </span>
                   </td>
-                  {showShopifyMapping && <td>{location.shopifyLocationId || '-'}</td>}
+                  <td>{location.shopifyLocationId || '-'}</td>
                   {canWrite && (
                     <td>
                       <div className="inline-actions">
@@ -351,18 +342,6 @@ export default function LocationsPage() {
                 onChange={handleFormChange}
               />
             </div>
-            {showShopifyMapping && (
-              <div className="input-group">
-                <label htmlFor="locationShopify">ID ubicación Shopify</label>
-                <input
-                  id="locationShopify"
-                  name="shopifyLocationId"
-                  value={formValues.shopifyLocationId}
-                  onChange={handleFormChange}
-                  placeholder="Ej: 123456789 o gid://shopify/Location/123456789"
-                />
-              </div>
-            )}
             <div className="input-group">
               <label htmlFor="locationShopify">ID ubicación Shopify</label>
               <input

--- a/frontend/src/pages/shopify/ShopifyPage.jsx
+++ b/frontend/src/pages/shopify/ShopifyPage.jsx
@@ -16,6 +16,18 @@ function formatMoney(value) {
   return new Intl.NumberFormat('es-AR', { style: 'currency', currency: 'ARS' }).format(Number(value) || 0);
 }
 
+function formatLocationQuantity(location) {
+  const parts = [];
+  if (location.boxes > 0) parts.push(`${location.boxes} caja(s)`);
+  if (location.units > 0) parts.push(`${location.units} unidad(es)`);
+  return parts.length > 0 ? parts.join(', ') : 'sin stock';
+}
+
+function getCurrentLocations(item) {
+  const locations = Array.isArray(item?.payload?.stockByLocation) ? item.payload.stockByLocation : [];
+  return locations.filter(location => (Number(location.boxes) || 0) > 0 || (Number(location.units) || 0) > 0);
+}
+
 export default function ShopifyPage() {
   const api = useApi();
   const { user } = useAuth();
@@ -123,7 +135,81 @@ export default function ShopifyPage() {
         {message && <div className="success-message">{message}</div>}
       </section>
       <section className="section-card">
-        {loading ? <LoadingIndicator /> : <><div className="table-toolbar"><span>{selectedIds.length} seleccionado(s) de {total}</span><button type="button" className="secondary-button" onClick={toggleVisible}>{allVisibleSelected ? 'Quitar visibles' : 'Seleccionar visibles'}</button></div><div className="table-responsive"><table className="data-table"><thead><tr><th><input type="checkbox" checked={allVisibleSelected} onChange={toggleVisible} /></th><th>Artículo</th><th>Grupo</th><th>Precio</th><th>Stock</th><th>Estado</th><th>Última sync</th><th>Payload Shopify</th></tr></thead><tbody>{items.map(item => <tr key={item.id}><td><input type="checkbox" checked={selectedSet.has(item.id)} onChange={() => toggleItem(item.id)} /></td><td><strong>{item.code}</strong><br /><span className="muted-text">{item.description}</span><br /><small>SKU: {item.sku || '-'}</small></td><td>{item.group?.name || '-'}</td><td>{formatMoney(item.precio)}</td><td>{item.payload.inventory.boxes} caja(s), {item.payload.inventory.units} unidad(es)</td><td><span className={`status-pill status-pill--${item.shopify.status}`}>{STATUS_LABELS[item.shopify.status] || item.shopify.status}</span></td><td>{formatDate(item.shopify.lastSyncedAt)}</td><td><small>{item.payload.title} · {item.payload.productType}</small></td></tr>)}{items.length === 0 && <tr><td colSpan="8">No hay artículos para mostrar.</td></tr>}</tbody></table></div><div className="pagination-controls"><button type="button" onClick={() => setPage(value => Math.max(1, value - 1))} disabled={page <= 1}>Anterior</button><span>Página {page} de {totalPages}</span><button type="button" onClick={() => setPage(value => Math.min(totalPages, value + 1))} disabled={page >= totalPages}>Siguiente</button></div></>}
+        {loading ? <LoadingIndicator /> : <>
+          <div className="table-toolbar">
+            <span>{selectedIds.length} seleccionado(s) de {total}</span>
+            <button type="button" className="secondary-button" onClick={toggleVisible}>
+              {allVisibleSelected ? 'Quitar visibles' : 'Seleccionar visibles'}
+            </button>
+          </div>
+          <div className="table-responsive">
+            <table className="data-table">
+              <thead>
+                <tr>
+                  <th><input type="checkbox" checked={allVisibleSelected} onChange={toggleVisible} /></th>
+                  <th>Artículo</th>
+                  <th>Grupo</th>
+                  <th>Precio</th>
+                  <th>Stock</th>
+                  <th>Ubicación actual</th>
+                  <th>Estado</th>
+                  <th>Última sync</th>
+                  <th>Payload Shopify</th>
+                </tr>
+              </thead>
+              <tbody>
+                {items.map(item => {
+                  const currentLocations = getCurrentLocations(item);
+                  return (
+                    <tr key={item.id}>
+                      <td>
+                        <input checked={selectedSet.has(item.id)} type="checkbox" onChange={() => toggleItem(item.id)} />
+                      </td>
+                      <td>
+                        <strong>{item.code}</strong><br />
+                        <span className="muted-text">{item.description}</span><br />
+                        <small>SKU: {item.sku || '-'}</small>
+                      </td>
+                      <td>{item.group?.name || '-'}</td>
+                      <td>{formatMoney(item.precio)}</td>
+                      <td>{item.payload.inventory.boxes} caja(s), {item.payload.inventory.units} unidad(es)</td>
+                      <td>
+                        {currentLocations.length > 0
+                          ? currentLocations.map(location => (
+                              <small key={location.locationId} className="muted-text" style={{ display: 'block' }}>
+                                {location.locationName}: {formatLocationQuantity(location)}
+                              </small>
+                            ))
+                          : '-'}
+                      </td>
+                      <td>
+                        <span className={`status-pill status-pill--${item.shopify.status}`}>
+                          {STATUS_LABELS[item.shopify.status] || item.shopify.status}
+                        </span>
+                      </td>
+                      <td>{formatDate(item.shopify.lastSyncedAt)}</td>
+                      <td><small>{item.payload.title} · {item.payload.productType}</small></td>
+                    </tr>
+                  );
+                })}
+                {items.length === 0 && <tr><td colSpan="9">No hay artículos para mostrar.</td></tr>}
+              </tbody>
+            </table>
+          </div>
+          <div className="pagination-controls">
+            <button type="button" onClick={() => setPage(value => Math.max(1, value - 1))} disabled={page <= 1}>
+              Anterior
+            </button>
+            <span>Página {page} de {totalPages}</span>
+            <button
+              type="button"
+              onClick={() => setPage(value => Math.min(totalPages, value + 1))}
+              disabled={page >= totalPages}
+            >
+              Siguiente
+            </button>
+          </div>
+        </>}
       </section>
     </div>
   );


### PR DESCRIPTION
### Motivation
- Make Shopify inventory webhook synchronization enabled by default to simplify integration and reflect expected behavior.
- Update documentation to document the new default and clarify how to opt out of automatic stock updates.
- Improve frontend visibility of Shopify mappings and per-location stock so operators can see where stock is present directly in the UI.

### Description
- Backend: changed `SHOPIFY_INVENTORY_WEBHOOK_SYNC_ENABLED` default to `true` in `backend/src/config.js` so webhook sync is enabled by default. 
- Docs: updated `docs/shopify-setup.md` to show `SHOPIFY_INVENTORY_WEBHOOK_SYNC_ENABLED=true` in the example `.env` and adjusted explanatory text to state the default is `true`.
- Frontend Locations: simplified `frontend/src/pages/locations/LocationsPage.jsx` by removing the `showShopifyMapping` flag and the extra `/shopify/config` request, always displaying and submitting the `shopifyLocationId` field, and adjusting the table column span accordingly.
- Frontend Shopify list: enhanced `frontend/src/pages/shopify/ShopifyPage.jsx` by adding `formatLocationQuantity` and `getCurrentLocations` helpers and a new table column `Ubicación actual` that shows per-location stock (boxes/units) for each item, and reworked the table markup for readability.

### Testing
- No automated tests were added or run as part of this change; existing test coverage was not modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6362f93354832a810ce36e0847136f)