### PR TITLE
Enable Shopify per-location inventory sync by default and surface mapping in UI

### DIFF
--- a/backend/src/config.js
+++ b/backend/src/config.js
@@ -41,7 +41,7 @@ const config = {
     apiVersion: process.env.SHOPIFY_API_VERSION || '2026-07',
     dryRun: normalizeBoolean(process.env.SHOPIFY_DRY_RUN) ?? true,
     defaultLocationId: process.env.SHOPIFY_DEFAULT_LOCATION_ID || '',
-    inventoryWebhookSyncEnabled: normalizeBoolean(process.env.SHOPIFY_INVENTORY_WEBHOOK_SYNC_ENABLED) ?? false,
+    inventoryWebhookSyncEnabled: normalizeBoolean(process.env.SHOPIFY_INVENTORY_WEBHOOK_SYNC_ENABLED) ?? true,
     publicBackendUrl: (process.env.PUBLIC_BACKEND_URL || process.env.BACKEND_PUBLIC_URL || '').replace(/\/$/, '')
   }
 };

--- a/backend/src/routes/shopify.js
+++ b/backend/src/routes/shopify.js
@@ -71,16 +71,26 @@ function buildShopifyMedia(item) {
 }
 
 function buildShopifyPayload(item, locations = []) {
-  const locationNames = new Map(locations.map(location => [String(location.id), location.name]));
+  const locationsById = new Map(
+    locations.map(location => [
+      String(location.id),
+      {
+        name: location.name,
+        shopifyLocationId: location.shopifyLocationId || null
+      }
+    ])
+  );
   const stockByLocation = [];
   const entries = item.stock instanceof Map ? Array.from(item.stock.entries()) : Object.entries(item.stock || {});
   entries.forEach(([locationId, quantity]) => {
     const boxes = Number(quantity?.boxes) || 0;
     const units = Number(quantity?.units) || 0;
     if (boxes <= 0 && units <= 0) return;
+    const locationInfo = locationsById.get(String(locationId));
     stockByLocation.push({
       locationId,
-      locationName: locationNames.get(String(locationId)) || 'Ubicación',
+      locationName: locationInfo?.name || 'Ubicación',
+      shopifyLocationId: locationInfo?.shopifyLocationId || null,
       boxes,
       units
     });
@@ -257,7 +267,8 @@ router.post(
         code: item.code,
         status: shopifyConfig.configured ? 'synced' : 'dry-run',
         productId: syncedProduct.productId,
-        handle: syncedProduct.handle
+        handle: syncedProduct.handle,
+        inventorySync: syncedProduct.inventorySync || null
       });
     }
     await recordAuditEvent({

--- a/backend/src/services/shopifyProductService.js
+++ b/backend/src/services/shopifyProductService.js
@@ -1,4 +1,5 @@
 const config = require('../config');
+const crypto = require('crypto');
 const { HttpError } = require('../utils/errors');
 const { getAdminAccessToken, normalizeShopDomain } = require('./shopifyAuthService');
 
@@ -60,6 +61,103 @@ function buildVariantInput(variantId, payload) {
     variant.inventoryItem = { sku: payload.sku };
   }
   return variant;
+}
+
+function shopifyGid(resource, value) {
+  const normalized = String(value || '').trim();
+  if (!normalized) return '';
+  if (normalized.startsWith('gid://shopify/')) return normalized;
+  return /^\d+$/.test(normalized) ? `gid://shopify/${resource}/${normalized}` : normalized;
+}
+
+function getLocationAvailableQuantity(location) {
+  return (Number(location?.boxes) || 0) + (Number(location?.units) || 0);
+}
+
+function getMappedInventoryQuantities(inventoryItemId, payload) {
+  const normalizedInventoryItemId = shopifyGid('InventoryItem', inventoryItemId);
+  if (!normalizedInventoryItemId) return [];
+  const locations = Array.isArray(payload?.stockByLocation) ? payload.stockByLocation : [];
+  return locations
+    .map(location => {
+      const locationId = shopifyGid('Location', location.shopifyLocationId);
+      if (!locationId) return null;
+      return {
+        inventoryItemId: normalizedInventoryItemId,
+        locationId,
+        quantity: getLocationAvailableQuantity(location),
+        compareQuantity: null
+      };
+    })
+    .filter(Boolean);
+}
+
+function isAlreadyActiveInventoryError(error) {
+  const message = String(error?.message || '').toLowerCase();
+  return message.includes('already') || message.includes('active') || message.includes('activado');
+}
+
+async function activateInventoryLocation(quantity) {
+  const query = `
+    mutation ActivateInventoryItem(
+      $inventoryItemId: ID!,
+      $locationId: ID!,
+      $available: Int,
+      $idempotencyKey: String!
+    ) {
+      inventoryActivate(inventoryItemId: $inventoryItemId, locationId: $locationId, available: $available)
+        @idempotent(key: $idempotencyKey) {
+        inventoryLevel { id }
+        userErrors { field message }
+      }
+    }
+  `;
+  const data = await shopifyGraphql(query, {
+    inventoryItemId: quantity.inventoryItemId,
+    locationId: quantity.locationId,
+    available: quantity.quantity,
+    idempotencyKey: crypto.randomUUID()
+  });
+  const userErrors = data.inventoryActivate?.userErrors || [];
+  const blockingErrors = userErrors.filter(error => !isAlreadyActiveInventoryError(error));
+  assertNoUserErrors('la activación de inventario por ubicación', blockingErrors);
+}
+
+async function setInventoryQuantities(quantities, referenceDocumentUri) {
+  const query = `
+    mutation InventorySet($input: InventorySetQuantitiesInput!, $idempotencyKey: String!) {
+      inventorySetQuantities(input: $input) @idempotent(key: $idempotencyKey) {
+        inventoryAdjustmentGroup { id }
+        userErrors { field message }
+      }
+    }
+  `;
+  const data = await shopifyGraphql(query, {
+    input: {
+      ignoreCompareQuantity: true,
+      name: 'available',
+      reason: 'correction',
+      referenceDocumentUri,
+      quantities
+    },
+    idempotencyKey: crypto.randomUUID()
+  });
+  assertNoUserErrors('la actualización de inventario por ubicación', data.inventorySetQuantities?.userErrors);
+}
+
+async function syncInventoryLevels(inventoryItemId, payload) {
+  const quantities = getMappedInventoryQuantities(inventoryItemId, payload);
+  if (quantities.length === 0) {
+    return { updated: 0, skipped: true };
+  }
+  for (const quantity of quantities) {
+    await activateInventoryLocation(quantity);
+  }
+  await setInventoryQuantities(
+    quantities,
+    `gestionthibe://shopify/inventory-sync/${encodeURIComponent(payload.sku || inventoryItemId)}`
+  );
+  return { updated: quantities.length, skipped: false };
 }
 
 async function updateDefaultVariant(productId, variantId, payload) {
@@ -189,10 +287,13 @@ async function updateShopifyProduct(productId, payload, status) {
 }
 
 async function syncShopifyProduct({ existingProductId, payload, status }) {
-  if (existingProductId) {
-    return updateShopifyProduct(existingProductId, payload, status);
-  }
-  return createShopifyProduct(payload, status);
+  const product = existingProductId
+    ? await updateShopifyProduct(existingProductId, payload, status)
+    : await createShopifyProduct(payload, status);
+  return {
+    ...product,
+    inventorySync: await syncInventoryLevels(product.inventoryItemId, payload)
+  };
 }
 
 async function archiveShopifyProduct(productId, payload = {}) {

--- a/docs/shopify-setup.md
+++ b/docs/shopify-setup.md
@@ -31,7 +31,7 @@ SHOPIFY_ADMIN_ACCESS_TOKEN=
 SHOPIFY_API_VERSION=2026-07
 SHOPIFY_DRY_RUN=true
 SHOPIFY_DEFAULT_LOCATION_ID=
-SHOPIFY_INVENTORY_WEBHOOK_SYNC_ENABLED=false
+SHOPIFY_INVENTORY_WEBHOOK_SYNC_ENABLED=true
 PUBLIC_BACKEND_URL=https://tu-dominio-o-ip
 ```
 
@@ -44,7 +44,7 @@ PUBLIC_BACKEND_URL=https://tu-dominio-o-ip
 | `SHOPIFY_API_VERSION` | No | Versión de Admin API. Por defecto: `2026-07`. |
 | `SHOPIFY_DRY_RUN` | No | Si está en `true`, el sistema prepara payloads y registra estado local sin llamar a Shopify. |
 | `SHOPIFY_DEFAULT_LOCATION_ID` | No | ID de ubicación Shopify para sincronizar inventario cuando se defina el mapeo. |
-| `SHOPIFY_INVENTORY_WEBHOOK_SYNC_ENABLED` | No | Habilita la aplicación automática de webhooks `inventory_levels/update` sobre el stock local. Por seguridad queda en `false` por defecto. |
+| `SHOPIFY_INVENTORY_WEBHOOK_SYNC_ENABLED` | No | Habilita la aplicación automática de webhooks `inventory_levels/update` sobre el stock local. Por defecto queda en `true`; usar `false` solo si se quiere recibir webhooks sin modificar stock local. |
 | `PUBLIC_BACKEND_URL` / `BACKEND_PUBLIC_URL` | Recomendado para imágenes | URL pública desde donde Shopify puede descargar imágenes guardadas en `uploads/items`. Debe apuntar al backend y ser accesible desde internet. |
 
 > Seguridad: el secreto y cualquier token solo deben existir en el backend. Nunca deben exponerse en React, commits, capturas ni logs.
@@ -69,11 +69,11 @@ Con esas credenciales, el backend ya puede obtener un token por `client_credenti
 - archivar producto para la baja;
 - actualizar variante/precio/SKU;
 - enviar imágenes públicas del artículo como media del producto;
-- mapear inventario por ubicación.
+- mapear inventario por ubicación y enviar la existencia disponible a Shopify cuando la ubicación local tenga `shopifyLocationId`.
 
 ## 5. Mapeo de ubicaciones y baja automática por ventas
 
-Para que una venta o cualquier ajuste de inventario en Shopify impacte el stock local sin intervención del usuario, primero activar explícitamente `SHOPIFY_INVENTORY_WEBHOOK_SYNC_ENABLED=true` en el backend. Por seguridad, si la variable queda en `false`, el webhook responde correctamente pero no modifica stock local.
+Para que una venta o cualquier ajuste de inventario en Shopify impacte el stock local sin intervención del usuario, `SHOPIFY_INVENTORY_WEBHOOK_SYNC_ENABLED` queda habilitado por defecto en `true`. Si la variable se configura en `false`, el webhook responde correctamente pero no modifica stock local.
 
 1. En el sistema, abrir **Ubicaciones** y cargar en cada depósito interno el **ID ubicación Shopify** correspondiente. Puede guardarse como número (`123456789`) o como GID (`gid://shopify/Location/123456789`).
 2. Sincronizar los artículos desde la pantalla **Shopify**. La sincronización guarda el `InventoryItem` de la variante Shopify en cada artículo local.

--- a/frontend/src/pages/locations/LocationsPage.jsx
+++ b/frontend/src/pages/locations/LocationsPage.jsx
@@ -38,7 +38,6 @@ export default function LocationsPage() {
   const [saving, setSaving] = useState(false);
   const [deletingId, setDeletingId] = useState(null);
   const [successMessage, setSuccessMessage] = useState('');
-  const [showShopifyMapping, setShowShopifyMapping] = useState(false);
 
   const normalizeLocation = location => {
     const rawId = location.id || location._id;
@@ -71,13 +70,8 @@ export default function LocationsPage() {
           setLoading(false);
           return;
         }
-        const [locationsResponse, shopifyConfigResponse] = await Promise.all([
-          api.get('/locations'),
-          api.get('/shopify/config').catch(() => null)
-        ]);
+        const response = await api.get('/locations');
         if (!active) return;
-        setShowShopifyMapping(Boolean(shopifyConfigResponse?.inventoryWebhookSyncEnabled));
-        const response = locationsResponse;
         const normalized = Array.isArray(response)
           ? response
               .map(normalizeLocation)
@@ -99,7 +93,7 @@ export default function LocationsPage() {
     };
   }, [api, canRead]);
 
-  const locationsTableColSpan = 5 + (showShopifyMapping ? 1 : 0) + (canWrite ? 1 : 0);
+  const locationsTableColSpan = 6 + (canWrite ? 1 : 0);
 
   const filteredLocations = useMemo(() => {
     if (filterType === 'all') {
@@ -147,9 +141,6 @@ export default function LocationsPage() {
     setError(null);
     try {
       const payload = { ...formValues, name: trimmedName };
-      if (!showShopifyMapping) {
-        delete payload.shopifyLocationId;
-      }
       if (editingId) {
         const updated = await api.put(`/locations/${editingId}`, payload);
         const normalized = normalizeLocation(updated);
@@ -253,7 +244,7 @@ export default function LocationsPage() {
                 <th>Descripción</th>
                 <th>Contacto</th>
                 <th>Estado</th>
-                {showShopifyMapping && <th>Shopify</th>}
+                <th>Shopify</th>
                 {canWrite && <th>Acciones</th>}
               </tr>
             </thead>
@@ -271,7 +262,7 @@ export default function LocationsPage() {
                       {location.status}
                     </span>
                   </td>
-                  {showShopifyMapping && <td>{location.shopifyLocationId || '-'}</td>}
+                  <td>{location.shopifyLocationId || '-'}</td>
                   {canWrite && (
                     <td>
                       <div className="inline-actions">
@@ -351,18 +342,6 @@ export default function LocationsPage() {
                 onChange={handleFormChange}
               />
             </div>
-            {showShopifyMapping && (
-              <div className="input-group">
-                <label htmlFor="locationShopify">ID ubicación Shopify</label>
-                <input
-                  id="locationShopify"
-                  name="shopifyLocationId"
-                  value={formValues.shopifyLocationId}
-                  onChange={handleFormChange}
-                  placeholder="Ej: 123456789 o gid://shopify/Location/123456789"
-                />
-              </div>
-            )}
             <div className="input-group">
               <label htmlFor="locationShopify">ID ubicación Shopify</label>
               <input

--- a/frontend/src/pages/shopify/ShopifyPage.jsx
+++ b/frontend/src/pages/shopify/ShopifyPage.jsx
@@ -16,6 +16,18 @@ function formatMoney(value) {
   return new Intl.NumberFormat('es-AR', { style: 'currency', currency: 'ARS' }).format(Number(value) || 0);
 }
 
+function formatLocationQuantity(location) {
+  const parts = [];
+  if (location.boxes > 0) parts.push(`${location.boxes} caja(s)`);
+  if (location.units > 0) parts.push(`${location.units} unidad(es)`);
+  return parts.length > 0 ? parts.join(', ') : 'sin stock';
+}
+
+function getCurrentLocations(item) {
+  const locations = Array.isArray(item?.payload?.stockByLocation) ? item.payload.stockByLocation : [];
+  return locations.filter(location => (Number(location.boxes) || 0) > 0 || (Number(location.units) || 0) > 0);
+}
+
 export default function ShopifyPage() {
   const api = useApi();
   const { user } = useAuth();
@@ -123,7 +135,81 @@ export default function ShopifyPage() {
         {message && <div className="success-message">{message}</div>}
       </section>
       <section className="section-card">
-        {loading ? <LoadingIndicator /> : <><div className="table-toolbar"><span>{selectedIds.length} seleccionado(s) de {total}</span><button type="button" className="secondary-button" onClick={toggleVisible}>{allVisibleSelected ? 'Quitar visibles' : 'Seleccionar visibles'}</button></div><div className="table-responsive"><table className="data-table"><thead><tr><th><input type="checkbox" checked={allVisibleSelected} onChange={toggleVisible} /></th><th>Artículo</th><th>Grupo</th><th>Precio</th><th>Stock</th><th>Estado</th><th>Última sync</th><th>Payload Shopify</th></tr></thead><tbody>{items.map(item => <tr key={item.id}><td><input type="checkbox" checked={selectedSet.has(item.id)} onChange={() => toggleItem(item.id)} /></td><td><strong>{item.code}</strong><br /><span className="muted-text">{item.description}</span><br /><small>SKU: {item.sku || '-'}</small></td><td>{item.group?.name || '-'}</td><td>{formatMoney(item.precio)}</td><td>{item.payload.inventory.boxes} caja(s), {item.payload.inventory.units} unidad(es)</td><td><span className={`status-pill status-pill--${item.shopify.status}`}>{STATUS_LABELS[item.shopify.status] || item.shopify.status}</span></td><td>{formatDate(item.shopify.lastSyncedAt)}</td><td><small>{item.payload.title} · {item.payload.productType}</small></td></tr>)}{items.length === 0 && <tr><td colSpan="8">No hay artículos para mostrar.</td></tr>}</tbody></table></div><div className="pagination-controls"><button type="button" onClick={() => setPage(value => Math.max(1, value - 1))} disabled={page <= 1}>Anterior</button><span>Página {page} de {totalPages}</span><button type="button" onClick={() => setPage(value => Math.min(totalPages, value + 1))} disabled={page >= totalPages}>Siguiente</button></div></>}
+        {loading ? <LoadingIndicator /> : <>
+          <div className="table-toolbar">
+            <span>{selectedIds.length} seleccionado(s) de {total}</span>
+            <button type="button" className="secondary-button" onClick={toggleVisible}>
+              {allVisibleSelected ? 'Quitar visibles' : 'Seleccionar visibles'}
+            </button>
+          </div>
+          <div className="table-responsive">
+            <table className="data-table">
+              <thead>
+                <tr>
+                  <th><input type="checkbox" checked={allVisibleSelected} onChange={toggleVisible} /></th>
+                  <th>Artículo</th>
+                  <th>Grupo</th>
+                  <th>Precio</th>
+                  <th>Stock</th>
+                  <th>Ubicación actual</th>
+                  <th>Estado</th>
+                  <th>Última sync</th>
+                  <th>Payload Shopify</th>
+                </tr>
+              </thead>
+              <tbody>
+                {items.map(item => {
+                  const currentLocations = getCurrentLocations(item);
+                  return (
+                    <tr key={item.id}>
+                      <td>
+                        <input checked={selectedSet.has(item.id)} type="checkbox" onChange={() => toggleItem(item.id)} />
+                      </td>
+                      <td>
+                        <strong>{item.code}</strong><br />
+                        <span className="muted-text">{item.description}</span><br />
+                        <small>SKU: {item.sku || '-'}</small>
+                      </td>
+                      <td>{item.group?.name || '-'}</td>
+                      <td>{formatMoney(item.precio)}</td>
+                      <td>{item.payload.inventory.boxes} caja(s), {item.payload.inventory.units} unidad(es)</td>
+                      <td>
+                        {currentLocations.length > 0
+                          ? currentLocations.map(location => (
+                              <small key={location.locationId} className="muted-text" style={{ display: 'block' }}>
+                                {location.locationName}: {formatLocationQuantity(location)}
+                              </small>
+                            ))
+                          : '-'}
+                      </td>
+                      <td>
+                        <span className={`status-pill status-pill--${item.shopify.status}`}>
+                          {STATUS_LABELS[item.shopify.status] || item.shopify.status}
+                        </span>
+                      </td>
+                      <td>{formatDate(item.shopify.lastSyncedAt)}</td>
+                      <td><small>{item.payload.title} · {item.payload.productType}</small></td>
+                    </tr>
+                  );
+                })}
+                {items.length === 0 && <tr><td colSpan="9">No hay artículos para mostrar.</td></tr>}
+              </tbody>
+            </table>
+          </div>
+          <div className="pagination-controls">
+            <button type="button" onClick={() => setPage(value => Math.max(1, value - 1))} disabled={page <= 1}>
+              Anterior
+            </button>
+            <span>Página {page} de {totalPages}</span>
+            <button
+              type="button"
+              onClick={() => setPage(value => Math.min(totalPages, value + 1))}
+              disabled={page >= totalPages}
+            >
+              Siguiente
+            </button>
+          </div>
+        </>}
       </section>
     </div>
   );


### PR DESCRIPTION
### Motivation
- Habilitar por defecto la sincronización de inventario entre la aplicación y Shopify y permitir mapear ubicaciones locales con IDs de Shopify para enviar existencias por ubicación. 
- Registrar en el payload y en los resultados de sincronización el estado de la operación de inventario para tener visibilidad de actualizaciones por ubicación. 
- Mostrar en la UI la columna de mapeo Shopify y detallar las ubicaciones actuales y sus cantidades por artículo. 

### Description
- Cambia el valor por defecto de `config.shopify.inventoryWebhookSyncEnabled` a `true` en `backend/src/config.js` y actualiza la documentación `docs/shopify-setup.md` para reflejar el nuevo comportamiento por defecto. 
- En `backend/src/routes/shopify.js` se incluye `shopifyLocationId` y `locationName` en el `stockByLocation` del payload generado, y se devuelve `inventorySync` en los resultados de la sincronización. 
- Se añade `backend/src/services/shopifyProductService.js` lógica nueva para mapear GIDs (`shopifyGid`), activar niveles de inventario por ubicación (`activateInventoryLocation`), aplicar cantidades (`setInventoryQuantities`) y un flujo `syncInventoryLevels` que activa ubicaciones y envía los ajustes a Shopify; se integra esta sincronización en `syncShopifyProduct`. 
- Frontend: en `frontend/src/pages/locations/LocationsPage.jsx` se expone siempre la columna y el campo `ID ubicación Shopify` y se permite editar/guardar `shopifyLocationId`; en `frontend/src/pages/shopify/ShopifyPage.jsx` se agrega la columna "Ubicación actual" que muestra las ubicaciones con stock y formatea las cantidades por `boxes`/`units`. 

### Testing
- No se ejecutaron suites de pruebas automatizadas como parte de este cambio en el rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6362f93354832a810ce36e0847136f)