### PR TITLE
Shopify: enable inventory sync, add inventory-level GraphQL sync, require HTTPS images and UI updates

### DIFF
--- a/backend/src/config.js
+++ b/backend/src/config.js
@@ -41,7 +41,7 @@ const config = {
     apiVersion: process.env.SHOPIFY_API_VERSION || '2026-07',
     dryRun: normalizeBoolean(process.env.SHOPIFY_DRY_RUN) ?? true,
     defaultLocationId: process.env.SHOPIFY_DEFAULT_LOCATION_ID || '',
-    inventoryWebhookSyncEnabled: normalizeBoolean(process.env.SHOPIFY_INVENTORY_WEBHOOK_SYNC_ENABLED) ?? false,
+    inventoryWebhookSyncEnabled: normalizeBoolean(process.env.SHOPIFY_INVENTORY_WEBHOOK_SYNC_ENABLED) ?? true,
     publicBackendUrl: (process.env.PUBLIC_BACKEND_URL || process.env.BACKEND_PUBLIC_URL || '').replace(/\/$/, '')
   }
 };

--- a/backend/src/routes/shopify.js
+++ b/backend/src/routes/shopify.js
@@ -45,11 +45,13 @@ function resolvePublicImageUrl(value) {
   if (typeof value !== 'string') return null;
   const trimmed = value.trim();
   if (!trimmed || /^data:image\//i.test(trimmed)) return null;
-  if (/^https?:\/\//i.test(trimmed)) return trimmed;
+  if (/^http:\/\//i.test(trimmed)) return null;
+  if (/^https:\/\//i.test(trimmed)) return trimmed;
   const publicBackendUrl = config.shopify.publicBackendUrl;
   if (!publicBackendUrl) return null;
   try {
-    return new URL(trimmed.replace(/^\/+/, ''), `${publicBackendUrl}/`).toString();
+    const publicUrl = new URL(trimmed.replace(/^\/+/, ''), `${publicBackendUrl}/`).toString();
+    return publicUrl.startsWith('https://') ? publicUrl : null;
   } catch (error) {
     return null;
   }
@@ -71,16 +73,26 @@ function buildShopifyMedia(item) {
 }
 
 function buildShopifyPayload(item, locations = []) {
-  const locationNames = new Map(locations.map(location => [String(location.id), location.name]));
+  const locationsById = new Map(
+    locations.map(location => [
+      String(location.id),
+      {
+        name: location.name,
+        shopifyLocationId: location.shopifyLocationId || null
+      }
+    ])
+  );
   const stockByLocation = [];
   const entries = item.stock instanceof Map ? Array.from(item.stock.entries()) : Object.entries(item.stock || {});
   entries.forEach(([locationId, quantity]) => {
     const boxes = Number(quantity?.boxes) || 0;
     const units = Number(quantity?.units) || 0;
     if (boxes <= 0 && units <= 0) return;
+    const locationInfo = locationsById.get(String(locationId));
     stockByLocation.push({
       locationId,
-      locationName: locationNames.get(String(locationId)) || 'Ubicación',
+      locationName: locationInfo?.name || 'Ubicación',
+      shopifyLocationId: locationInfo?.shopifyLocationId || null,
       boxes,
       units
     });
@@ -257,7 +269,8 @@ router.post(
         code: item.code,
         status: shopifyConfig.configured ? 'synced' : 'dry-run',
         productId: syncedProduct.productId,
-        handle: syncedProduct.handle
+        handle: syncedProduct.handle,
+        inventorySync: syncedProduct.inventorySync || null
       });
     }
     await recordAuditEvent({

--- a/backend/src/services/shopifyProductService.js
+++ b/backend/src/services/shopifyProductService.js
@@ -1,4 +1,5 @@
 const config = require('../config');
+const crypto = require('crypto');
 const { HttpError } = require('../utils/errors');
 const { getAdminAccessToken, normalizeShopDomain } = require('./shopifyAuthService');
 
@@ -60,6 +61,132 @@ function buildVariantInput(variantId, payload) {
     variant.inventoryItem = { sku: payload.sku };
   }
   return variant;
+}
+
+function shopifyGid(resource, value) {
+  const normalized = String(value || '').trim();
+  if (!normalized) return '';
+  if (normalized.startsWith('gid://shopify/')) return normalized;
+  return /^\d+$/.test(normalized) ? `gid://shopify/${resource}/${normalized}` : normalized;
+}
+
+function getLocationAvailableQuantity(location) {
+  return (Number(location?.boxes) || 0) + (Number(location?.units) || 0);
+}
+
+function getMappedInventoryQuantities(inventoryItemId, payload) {
+  const normalizedInventoryItemId = shopifyGid('InventoryItem', inventoryItemId);
+  if (!normalizedInventoryItemId) return [];
+  const locations = Array.isArray(payload?.stockByLocation) ? payload.stockByLocation : [];
+  return locations
+    .map(location => {
+      const locationId = shopifyGid('Location', location.shopifyLocationId);
+      if (!locationId) return null;
+      return {
+        inventoryItemId: normalizedInventoryItemId,
+        locationId,
+        quantity: getLocationAvailableQuantity(location)
+      };
+    })
+    .filter(Boolean);
+}
+
+async function getCurrentAvailableQuantity(inventoryItemId, locationId) {
+  const query = `
+    query InventoryLevelAvailable($inventoryItemId: ID!, $locationId: ID!) {
+      inventoryItem(id: $inventoryItemId) {
+        inventoryLevel(locationId: $locationId, includeInactive: true) {
+          quantities(names: ["available"]) {
+            name
+            quantity
+          }
+        }
+      }
+    }
+  `;
+  const data = await shopifyGraphql(query, { inventoryItemId, locationId });
+  const available = data.inventoryItem?.inventoryLevel?.quantities?.find(quantity => quantity.name === 'available');
+  return Number(available?.quantity) || 0;
+}
+
+async function withCurrentInventoryQuantities(quantities) {
+  const resolvedQuantities = [];
+  for (const quantity of quantities) {
+    const currentQuantity = await getCurrentAvailableQuantity(quantity.inventoryItemId, quantity.locationId);
+    resolvedQuantities.push({
+      ...quantity,
+      changeFromQuantity: currentQuantity
+    });
+  }
+  return resolvedQuantities;
+}
+
+function isAlreadyActiveInventoryError(error) {
+  const message = String(error?.message || '').toLowerCase();
+  return message.includes('already') || message.includes('active') || message.includes('activado');
+}
+
+async function activateInventoryLocation(quantity) {
+  const query = `
+    mutation ActivateInventoryItem(
+      $inventoryItemId: ID!,
+      $locationId: ID!,
+      $available: Int,
+      $idempotencyKey: String!
+    ) {
+      inventoryActivate(inventoryItemId: $inventoryItemId, locationId: $locationId, available: $available)
+        @idempotent(key: $idempotencyKey) {
+        inventoryLevel { id }
+        userErrors { field message }
+      }
+    }
+  `;
+  const data = await shopifyGraphql(query, {
+    inventoryItemId: quantity.inventoryItemId,
+    locationId: quantity.locationId,
+    available: quantity.quantity,
+    idempotencyKey: crypto.randomUUID()
+  });
+  const userErrors = data.inventoryActivate?.userErrors || [];
+  const blockingErrors = userErrors.filter(error => !isAlreadyActiveInventoryError(error));
+  assertNoUserErrors('la activación de inventario por ubicación', blockingErrors);
+}
+
+async function setInventoryQuantities(quantities, referenceDocumentUri) {
+  const query = `
+    mutation InventorySet($input: InventorySetQuantitiesInput!, $idempotencyKey: String!) {
+      inventorySetQuantities(input: $input) @idempotent(key: $idempotencyKey) {
+        inventoryAdjustmentGroup { id }
+        userErrors { field message }
+      }
+    }
+  `;
+  const data = await shopifyGraphql(query, {
+    input: {
+      name: 'available',
+      reason: 'correction',
+      referenceDocumentUri,
+      quantities
+    },
+    idempotencyKey: crypto.randomUUID()
+  });
+  assertNoUserErrors('la actualización de inventario por ubicación', data.inventorySetQuantities?.userErrors);
+}
+
+async function syncInventoryLevels(inventoryItemId, payload) {
+  const quantities = getMappedInventoryQuantities(inventoryItemId, payload);
+  if (quantities.length === 0) {
+    return { updated: 0, skipped: true };
+  }
+  for (const quantity of quantities) {
+    await activateInventoryLocation(quantity);
+  }
+  const quantitiesWithCurrentValues = await withCurrentInventoryQuantities(quantities);
+  await setInventoryQuantities(
+    quantitiesWithCurrentValues,
+    `gestionthibe://shopify/inventory-sync/${encodeURIComponent(payload.sku || inventoryItemId)}`
+  );
+  return { updated: quantities.length, skipped: false };
 }
 
 async function updateDefaultVariant(productId, variantId, payload) {
@@ -141,7 +268,6 @@ async function appendProductMediaIfEmpty(productId, media = []) {
     mutation productUpdateMedia($product: ProductUpdateInput!, $media: [CreateMediaInput!]) {
       productUpdate(product: $product, media: $media) {
         product { id }
-        media { id status mediaContentType }
         userErrors { field message }
       }
     }
@@ -189,10 +315,13 @@ async function updateShopifyProduct(productId, payload, status) {
 }
 
 async function syncShopifyProduct({ existingProductId, payload, status }) {
-  if (existingProductId) {
-    return updateShopifyProduct(existingProductId, payload, status);
-  }
-  return createShopifyProduct(payload, status);
+  const product = existingProductId
+    ? await updateShopifyProduct(existingProductId, payload, status)
+    : await createShopifyProduct(payload, status);
+  return {
+    ...product,
+    inventorySync: await syncInventoryLevels(product.inventoryItemId, payload)
+  };
 }
 
 async function archiveShopifyProduct(productId, payload = {}) {

--- a/docs/demo-deployment.md
+++ b/docs/demo-deployment.md
@@ -169,7 +169,98 @@ Si ya tienes una copia, actualízala con `git pull`.
 2. Inicia sesión con las credenciales del administrador definidas en el backend (`admin@example.com` / `ChangeMe123!`, salvo cambios).
 3. Realiza acciones de prueba: crear un artículo, generar una solicitud de movimiento y revisar los reportes.
 
-## 7. Resolución de problemas frecuentes
+
+## 7. HTTPS público para Shopify manteniendo HTTP local/demo
+
+Shopify puede seguir conviviendo con la demo HTTP. La idea es **no apagar** los servicios actuales:
+
+- frontend demo: `http://<IP>:4173`;
+- backend demo/API: `http://<IP>:3000`;
+
+Y agregar una entrada HTTPS pública solo para que Shopify descargue imágenes y, si se desea, llame webhooks/API:
+
+```env
+PUBLIC_BACKEND_URL=https://api.tu-dominio.com
+```
+
+> Importante: para certificados confiables de Let's Encrypt necesitás un dominio o subdominio apuntando al servidor. Con una IP pública sin dominio no alcanza para un certificado válido que Shopify acepte. Para pruebas rápidas se puede usar un túnel HTTPS como Cloudflare Tunnel o ngrok y poner esa URL en `PUBLIC_BACKEND_URL`.
+
+### Opción recomendada con Nginx + Certbot
+
+1. Crear un DNS tipo `A` apuntando al servidor, por ejemplo:
+
+   ```text
+   api.tu-dominio.com -> <IP_DEL_SERVIDOR>
+   ```
+
+2. Instalar Nginx y Certbot en Ubuntu/Debian:
+
+   ```bash
+   sudo apt update
+   sudo apt install -y nginx certbot python3-certbot-nginx
+   ```
+
+3. Crear el sitio de Nginx para proxy al backend local `3000`:
+
+   ```nginx
+   server {
+       listen 80;
+       server_name api.tu-dominio.com;
+
+       location / {
+           proxy_pass http://127.0.0.1:3000;
+           proxy_http_version 1.1;
+           proxy_set_header Host $host;
+           proxy_set_header X-Real-IP $remote_addr;
+           proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+           proxy_set_header X-Forwarded-Proto $scheme;
+       }
+   }
+   ```
+
+   Guardarlo, por ejemplo, en:
+
+   ```bash
+   sudo nano /etc/nginx/sites-available/gestionthibe-api
+   sudo ln -s /etc/nginx/sites-available/gestionthibe-api /etc/nginx/sites-enabled/gestionthibe-api
+   sudo nginx -t
+   sudo systemctl reload nginx
+   ```
+
+4. Emitir el certificado HTTPS:
+
+   ```bash
+   sudo certbot --nginx -d api.tu-dominio.com
+   ```
+
+5. Configurar el backend:
+
+   ```env
+   PUBLIC_BACKEND_URL=https://api.tu-dominio.com
+   ```
+
+6. Reiniciar el backend para que tome el `.env`.
+
+7. Verificar desde navegador/incógnito o desde otra red:
+
+   ```text
+   https://api.tu-dominio.com/uploads/items/1778891837425-9cb20abbfed8eeed.png
+   ```
+
+Si esa URL HTTPS abre la imagen sin login, Shopify debería poder procesarla.
+
+### ¿Sigue funcionando por HTTP?
+
+Sí. Mientras no apagues los procesos ni cierres puertos, estas URLs pueden seguir funcionando:
+
+```text
+http://<IP>:4173
+http://<IP>:3000
+```
+
+Nginx agrega una entrada adicional por HTTPS; no reemplaza necesariamente la demo HTTP.
+
+## 8. Resolución de problemas frecuentes
 
 - **El backend no arranca**: revisa la cadena `MONGO_URI` y que MongoDB esté en ejecución (`docker ps` o `systemctl status mongod`).
 - **Error de CORS**: confirma que `VITE_API_BASE_URL` usa la misma URL y puerto en la que está publicado el backend.

--- a/docs/shopify-setup.md
+++ b/docs/shopify-setup.md
@@ -10,6 +10,7 @@ Para que el ABM de Shopify deje de funcionar como preparación local y pueda con
 - **Permisos/scopes Admin API** mínimos:
   - `read_products`
   - `write_products`
+  - `write_files`
   - `read_inventory`
   - `write_inventory`
   - `read_locations`
@@ -31,7 +32,7 @@ SHOPIFY_ADMIN_ACCESS_TOKEN=
 SHOPIFY_API_VERSION=2026-07
 SHOPIFY_DRY_RUN=true
 SHOPIFY_DEFAULT_LOCATION_ID=
-SHOPIFY_INVENTORY_WEBHOOK_SYNC_ENABLED=false
+SHOPIFY_INVENTORY_WEBHOOK_SYNC_ENABLED=true
 PUBLIC_BACKEND_URL=https://tu-dominio-o-ip
 ```
 
@@ -44,8 +45,8 @@ PUBLIC_BACKEND_URL=https://tu-dominio-o-ip
 | `SHOPIFY_API_VERSION` | No | Versión de Admin API. Por defecto: `2026-07`. |
 | `SHOPIFY_DRY_RUN` | No | Si está en `true`, el sistema prepara payloads y registra estado local sin llamar a Shopify. |
 | `SHOPIFY_DEFAULT_LOCATION_ID` | No | ID de ubicación Shopify para sincronizar inventario cuando se defina el mapeo. |
-| `SHOPIFY_INVENTORY_WEBHOOK_SYNC_ENABLED` | No | Habilita la aplicación automática de webhooks `inventory_levels/update` sobre el stock local. Por seguridad queda en `false` por defecto. |
-| `PUBLIC_BACKEND_URL` / `BACKEND_PUBLIC_URL` | Recomendado para imágenes | URL pública desde donde Shopify puede descargar imágenes guardadas en `uploads/items`. Debe apuntar al backend y ser accesible desde internet. |
+| `SHOPIFY_INVENTORY_WEBHOOK_SYNC_ENABLED` | No | Habilita la aplicación automática de webhooks `inventory_levels/update` sobre el stock local. Por defecto queda en `true`; usar `false` solo si se quiere recibir webhooks sin modificar stock local. |
+| `PUBLIC_BACKEND_URL` / `BACKEND_PUBLIC_URL` | Requerido para enviar imágenes locales | URL pública HTTPS desde donde Shopify puede descargar imágenes guardadas en `uploads/items`. Debe apuntar al backend y ser accesible desde internet. Las imágenes en formato `data:image/...` o servidas por `http://` quedan visibles en Thibe, pero no se envían a Shopify porque Shopify necesita una URL pública HTTPS estable. Si Shopify informa errores de procesamiento multimedia, validar que la app tenga `write_files`, que la URL abra desde internet sin login y que el archivo no sea demasiado pesado. |
 
 > Seguridad: el secreto y cualquier token solo deben existir en el backend. Nunca deben exponerse en React, commits, capturas ni logs.
 
@@ -69,11 +70,11 @@ Con esas credenciales, el backend ya puede obtener un token por `client_credenti
 - archivar producto para la baja;
 - actualizar variante/precio/SKU;
 - enviar imágenes públicas del artículo como media del producto;
-- mapear inventario por ubicación.
+- mapear inventario por ubicación y enviar la existencia disponible a Shopify cuando la ubicación local tenga `shopifyLocationId`.
 
 ## 5. Mapeo de ubicaciones y baja automática por ventas
 
-Para que una venta o cualquier ajuste de inventario en Shopify impacte el stock local sin intervención del usuario, primero activar explícitamente `SHOPIFY_INVENTORY_WEBHOOK_SYNC_ENABLED=true` en el backend. Por seguridad, si la variable queda en `false`, el webhook responde correctamente pero no modifica stock local.
+Para que una venta o cualquier ajuste de inventario en Shopify impacte el stock local sin intervención del usuario, `SHOPIFY_INVENTORY_WEBHOOK_SYNC_ENABLED` queda habilitado por defecto en `true`. Si la variable se configura en `false`, el webhook responde correctamente pero no modifica stock local.
 
 1. En el sistema, abrir **Ubicaciones** y cargar en cada depósito interno el **ID ubicación Shopify** correspondiente. Puede guardarse como número (`123456789`) o como GID (`gid://shopify/Location/123456789`).
 2. Sincronizar los artículos desde la pantalla **Shopify**. La sincronización guarda el `InventoryItem` de la variante Shopify en cada artículo local.

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -530,6 +530,27 @@ th {
   width: 100%;
 }
 
+.shopify-image-summary {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.shopify-image-thumbnails {
+  display: flex;
+  gap: 0.35rem;
+  align-items: center;
+}
+
+.shopify-image-thumbnails img {
+  width: 42px;
+  height: 42px;
+  border-radius: 6px;
+  object-fit: cover;
+  border: 1px solid #e2e8f0;
+  background-color: #f8fafc;
+}
+
 .image-lightbox {
   position: fixed;
   inset: 0;

--- a/frontend/src/pages/locations/LocationsPage.jsx
+++ b/frontend/src/pages/locations/LocationsPage.jsx
@@ -38,7 +38,6 @@ export default function LocationsPage() {
   const [saving, setSaving] = useState(false);
   const [deletingId, setDeletingId] = useState(null);
   const [successMessage, setSuccessMessage] = useState('');
-  const [showShopifyMapping, setShowShopifyMapping] = useState(false);
 
   const normalizeLocation = location => {
     const rawId = location.id || location._id;
@@ -71,13 +70,8 @@ export default function LocationsPage() {
           setLoading(false);
           return;
         }
-        const [locationsResponse, shopifyConfigResponse] = await Promise.all([
-          api.get('/locations'),
-          api.get('/shopify/config').catch(() => null)
-        ]);
+        const response = await api.get('/locations');
         if (!active) return;
-        setShowShopifyMapping(Boolean(shopifyConfigResponse?.inventoryWebhookSyncEnabled));
-        const response = locationsResponse;
         const normalized = Array.isArray(response)
           ? response
               .map(normalizeLocation)
@@ -99,7 +93,7 @@ export default function LocationsPage() {
     };
   }, [api, canRead]);
 
-  const locationsTableColSpan = 5 + (showShopifyMapping ? 1 : 0) + (canWrite ? 1 : 0);
+  const locationsTableColSpan = 6 + (canWrite ? 1 : 0);
 
   const filteredLocations = useMemo(() => {
     if (filterType === 'all') {
@@ -147,9 +141,6 @@ export default function LocationsPage() {
     setError(null);
     try {
       const payload = { ...formValues, name: trimmedName };
-      if (!showShopifyMapping) {
-        delete payload.shopifyLocationId;
-      }
       if (editingId) {
         const updated = await api.put(`/locations/${editingId}`, payload);
         const normalized = normalizeLocation(updated);
@@ -220,7 +211,7 @@ export default function LocationsPage() {
       </p>
 
       {error && <ErrorMessage error={error} />}
-      {successMessage && <div className="success-message">{successMessage}</div>}
+      {successMessage && <div className="success-message" role="status">{successMessage}</div>}
 
       <div className="section-card">
         <div className="flex-between" style={{ alignItems: 'center' }}>
@@ -253,7 +244,7 @@ export default function LocationsPage() {
                 <th>Descripción</th>
                 <th>Contacto</th>
                 <th>Estado</th>
-                {showShopifyMapping && <th>Shopify</th>}
+                <th>Shopify</th>
                 {canWrite && <th>Acciones</th>}
               </tr>
             </thead>
@@ -271,7 +262,7 @@ export default function LocationsPage() {
                       {location.status}
                     </span>
                   </td>
-                  {showShopifyMapping && <td>{location.shopifyLocationId || '-'}</td>}
+                  <td>{location.shopifyLocationId || '-'}</td>
                   {canWrite && (
                     <td>
                       <div className="inline-actions">
@@ -318,6 +309,7 @@ export default function LocationsPage() {
               </button>
             )}
           </div>
+          {successMessage && <div className="success-message" role="status">{successMessage}</div>}
           <form
             className="form-grid"
             style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))' }}
@@ -351,18 +343,6 @@ export default function LocationsPage() {
                 onChange={handleFormChange}
               />
             </div>
-            {showShopifyMapping && (
-              <div className="input-group">
-                <label htmlFor="locationShopify">ID ubicación Shopify</label>
-                <input
-                  id="locationShopify"
-                  name="shopifyLocationId"
-                  value={formValues.shopifyLocationId}
-                  onChange={handleFormChange}
-                  placeholder="Ej: 123456789 o gid://shopify/Location/123456789"
-                />
-              </div>
-            )}
             <div className="input-group">
               <label htmlFor="locationShopify">ID ubicación Shopify</label>
               <input

--- a/frontend/src/pages/shopify/ShopifyPage.jsx
+++ b/frontend/src/pages/shopify/ShopifyPage.jsx
@@ -3,8 +3,13 @@ import useApi from '../../hooks/useApi.js';
 import { useAuth } from '../../context/AuthContext.jsx';
 import LoadingIndicator from '../../components/LoadingIndicator.jsx';
 import ErrorMessage from '../../components/ErrorMessage.jsx';
+import { API_ROOT_URL } from '../../utils/apiConfig.js';
 
 const STATUS_LABELS = { draft: 'Borrador', active: 'Activo', archived: 'Archivado', deleted: 'Eliminado' };
+
+function getUpdatedInventoryLocations(results = []) {
+  return results.reduce((total, result) => total + (Number(result?.inventorySync?.updated) || 0), 0);
+}
 
 function formatDate(value) {
   if (!value) return 'Sin sincronizar';
@@ -14,6 +19,38 @@ function formatDate(value) {
 function formatMoney(value) {
   if (value === null || value === undefined || value === '') return '-';
   return new Intl.NumberFormat('es-AR', { style: 'currency', currency: 'ARS' }).format(Number(value) || 0);
+}
+
+function formatLocationQuantity(location) {
+  const parts = [];
+  if (location.boxes > 0) parts.push(`${location.boxes} caja(s)`);
+  if (location.units > 0) parts.push(`${location.units} unidad(es)`);
+  return parts.length > 0 ? parts.join(', ') : 'sin stock';
+}
+
+function getCurrentLocations(item) {
+  const locations = Array.isArray(item?.payload?.stockByLocation) ? item.payload.stockByLocation : [];
+  return locations.filter(location => (Number(location.boxes) || 0) > 0 || (Number(location.units) || 0) > 0);
+}
+
+function getImageUrl(path) {
+  if (!path) return '';
+  if (/^data:image\//i.test(path) || /^https?:\/\//i.test(path)) return path;
+  return `${API_ROOT_URL}/${String(path).replace(/^\/+/, '')}`;
+}
+
+function getShopifyImageSummary(item) {
+  const images = Array.isArray(item?.payload?.images) ? item.payload.images : [];
+  const media = Array.isArray(item?.payload?.media) ? item.payload.media : [];
+  return {
+    images,
+    media,
+    previewImages: images.slice(0, 3).map((image, index) => ({
+      src: getImageUrl(image),
+      alt: `${item.code || item.sku || 'Artículo'} · imagen ${index + 1}`,
+      key: `${item.id}-${index}-${image}`
+    }))
+  };
 }
 
 export default function ShopifyPage() {
@@ -81,7 +118,11 @@ export default function ShopifyPage() {
       const endpoint = action === 'archive' ? '/shopify/products/archive' : '/shopify/products/sync';
       const data = await api.post(endpoint, { itemIds: selectedIds, status });
       const mode = data.config?.dryRun ? ' (dry-run: no se llamó a Shopify)' : '';
-      setMessage(`Operación completada: ${data.processed} artículo(s) procesado(s)${mode}.`);
+      const updatedInventoryLocations = getUpdatedInventoryLocations(data.results || []);
+      const inventoryDetail = updatedInventoryLocations > 0
+        ? ` Inventario actualizado en ${updatedInventoryLocations} ubicación(es).`
+        : '';
+      setMessage(`Actualización completada correctamente: ${data.processed} artículo(s) procesado(s)${mode}.${inventoryDetail}`);
       setSelectedIds([]);
       await fetchItems();
     } catch (err) {
@@ -106,6 +147,7 @@ export default function ShopifyPage() {
                   : shopifyConfig.configured
                     ? `credenciales cargadas (${shopifyConfig.authMode})`
                     : 'faltan credenciales'}
+                {' '}· imágenes públicas {shopifyConfig.hasPublicBackendUrl ? 'configuradas' : 'sin configurar'}
               </p>
             )}
           </div>
@@ -119,11 +161,110 @@ export default function ShopifyPage() {
           <label>Buscar<input value={filters.search} onChange={event => { setFilters(current => ({ ...current, search: event.target.value })); setPage(1); }} placeholder="Código, SKU o descripción" /></label>
           <label>Estado Shopify<select value={filters.status} onChange={event => { setFilters(current => ({ ...current, status: event.target.value })); setPage(1); }}><option value="">Todos</option><option value="draft">Borrador</option><option value="active">Activo</option><option value="archived">Archivado</option></select></label>
         </div>
-        {error && <ErrorMessage message={error} />}
-        {message && <div className="success-message">{message}</div>}
+        {error && <ErrorMessage error={error} />}
+        {message && <div className="success-message" role="status">{message}</div>}
       </section>
       <section className="section-card">
-        {loading ? <LoadingIndicator /> : <><div className="table-toolbar"><span>{selectedIds.length} seleccionado(s) de {total}</span><button type="button" className="secondary-button" onClick={toggleVisible}>{allVisibleSelected ? 'Quitar visibles' : 'Seleccionar visibles'}</button></div><div className="table-responsive"><table className="data-table"><thead><tr><th><input type="checkbox" checked={allVisibleSelected} onChange={toggleVisible} /></th><th>Artículo</th><th>Grupo</th><th>Precio</th><th>Stock</th><th>Estado</th><th>Última sync</th><th>Payload Shopify</th></tr></thead><tbody>{items.map(item => <tr key={item.id}><td><input type="checkbox" checked={selectedSet.has(item.id)} onChange={() => toggleItem(item.id)} /></td><td><strong>{item.code}</strong><br /><span className="muted-text">{item.description}</span><br /><small>SKU: {item.sku || '-'}</small></td><td>{item.group?.name || '-'}</td><td>{formatMoney(item.precio)}</td><td>{item.payload.inventory.boxes} caja(s), {item.payload.inventory.units} unidad(es)</td><td><span className={`status-pill status-pill--${item.shopify.status}`}>{STATUS_LABELS[item.shopify.status] || item.shopify.status}</span></td><td>{formatDate(item.shopify.lastSyncedAt)}</td><td><small>{item.payload.title} · {item.payload.productType}</small></td></tr>)}{items.length === 0 && <tr><td colSpan="8">No hay artículos para mostrar.</td></tr>}</tbody></table></div><div className="pagination-controls"><button type="button" onClick={() => setPage(value => Math.max(1, value - 1))} disabled={page <= 1}>Anterior</button><span>Página {page} de {totalPages}</span><button type="button" onClick={() => setPage(value => Math.min(totalPages, value + 1))} disabled={page >= totalPages}>Siguiente</button></div></>}
+        {loading ? <LoadingIndicator /> : <>
+          <div className="table-toolbar">
+            <span>{selectedIds.length} seleccionado(s) de {total}</span>
+            <button type="button" className="secondary-button" onClick={toggleVisible}>
+              {allVisibleSelected ? 'Quitar visibles' : 'Seleccionar visibles'}
+            </button>
+          </div>
+          <div className="table-responsive">
+            <table className="data-table">
+              <thead>
+                <tr>
+                  <th><input type="checkbox" checked={allVisibleSelected} onChange={toggleVisible} /></th>
+                  <th>Artículo</th>
+                  <th>Grupo</th>
+                  <th>Precio</th>
+                  <th>Stock</th>
+                  <th>Ubicación actual</th>
+                  <th>Imágenes</th>
+                  <th>Estado</th>
+                  <th>Última sync</th>
+                  <th>Payload Shopify</th>
+                </tr>
+              </thead>
+              <tbody>
+                {items.map(item => {
+                  const currentLocations = getCurrentLocations(item);
+                  const imageSummary = getShopifyImageSummary(item);
+                  return (
+                    <tr key={item.id}>
+                      <td>
+                        <input checked={selectedSet.has(item.id)} type="checkbox" onChange={() => toggleItem(item.id)} />
+                      </td>
+                      <td>
+                        <strong>{item.code}</strong><br />
+                        <span className="muted-text">{item.description}</span><br />
+                        <small>SKU: {item.sku || '-'}</small>
+                      </td>
+                      <td>{item.group?.name || '-'}</td>
+                      <td>{formatMoney(item.precio)}</td>
+                      <td>{item.payload.inventory.boxes} caja(s), {item.payload.inventory.units} unidad(es)</td>
+                      <td>
+                        {currentLocations.length > 0
+                          ? currentLocations.map(location => (
+                              <small key={location.locationId} className="muted-text" style={{ display: 'block' }}>
+                                {location.locationName}: {formatLocationQuantity(location)}
+                              </small>
+                            ))
+                          : '-'}
+                      </td>
+                      <td>
+                        {imageSummary.images.length > 0 ? (
+                          <div className="shopify-image-summary">
+                            <div className="shopify-image-thumbnails">
+                              {imageSummary.previewImages.map(image => (
+                                <img key={image.key} src={image.src} alt={image.alt} loading="lazy" />
+                              ))}
+                            </div>
+                            <small className="muted-text">
+                              {imageSummary.images.length} asociada(s) · {imageSummary.media.length} enviable(s)
+                            </small>
+                            {imageSummary.media.length === 0 && (
+                              <small className="muted-text" style={{ display: 'block' }}>
+                                Requiere URL pública HTTPS para Shopify
+                              </small>
+                            )}
+                          </div>
+                        ) : '-'}
+                      </td>
+                      <td>
+                        <span className={`status-pill status-pill--${item.shopify.status}`}>
+                          {STATUS_LABELS[item.shopify.status] || item.shopify.status}
+                        </span>
+                      </td>
+                      <td>{formatDate(item.shopify.lastSyncedAt)}</td>
+                      <td>
+                        <small>
+                          {item.payload.title} · {item.payload.productType} · {imageSummary.media.length} imagen(es) para Shopify
+                        </small>
+                      </td>
+                    </tr>
+                  );
+                })}
+                {items.length === 0 && <tr><td colSpan="10">No hay artículos para mostrar.</td></tr>}
+              </tbody>
+            </table>
+          </div>
+          <div className="pagination-controls">
+            <button type="button" onClick={() => setPage(value => Math.max(1, value - 1))} disabled={page <= 1}>
+              Anterior
+            </button>
+            <span>Página {page} de {totalPages}</span>
+            <button
+              type="button"
+              onClick={() => setPage(value => Math.min(totalPages, value + 1))}
+              disabled={page >= totalPages}
+            >
+              Siguiente
+            </button>
+          </div>
+        </>}
       </section>
     </div>
   );

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -5,6 +5,12 @@ export default defineConfig({
   plugins: [react()],
   server: {
     host: '0.0.0.0',
-    port: 5173
+    port: 5173,
+    allowedHosts: ['th.linsse.com']
+  },
+  preview: {
+    host: '0.0.0.0',
+    port: 4173,
+    allowedHosts: ['th.linsse.com']
   }
 });


### PR DESCRIPTION
### Motivation

- Enable automatic inventory webhook-driven sync by default and provide server-side logic to push inventory levels to Shopify. 
- Ensure images sent to Shopify are publicly accessible over HTTPS and avoid sending `http` or data URLs to prevent Shopify upload failures. 
- Improve frontend UX to expose Shopify location mapping, show image previews and inventory-per-location details, and document HTTPS deployment for demos.

### Description

- Backend config: set `SHOPIFY_INVENTORY_WEBHOOK_SYNC_ENABLED` default to `true` and enforce `publicBackendUrl` image resolution only for `https://` URLs in `resolvePublicImageUrl` in `src/config.js` and `src/routes/shopify.js`. 
- Inventory sync service: add a full inventory-level sync flow in `src/services/shopifyProductService.js` including GID normalization (`shopifyGid`), mapping quantities per Shopify `Location`, GraphQL calls to read current available quantities, `inventoryActivate` (idempotent) and `inventorySetQuantities` mutations, and include `inventorySync` details in `syncShopifyProduct` results. 
- Payload and mapping: include `shopifyLocationId` in `buildShopifyPayload` and return per-location info (`shopifyLocationId`, `locationName`) so inventory can be mapped and synced. 
- Frontend/UI: always show and allow editing `shopifyLocationId` on the Locations page, add ARIA `role=

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6362f93354832a810ce36e0847136f)