### PR TITLE
Agregar filtro de artículos por ubicación

### DIFF
--- a/backend/src/routes/items.js
+++ b/backend/src/routes/items.js
@@ -529,7 +529,7 @@ router.get(
       await ensureItemSkus();
     }
 
-    const { page = '1', pageSize = '20', groupId, search, sku, gender, size, color } = req.query || {};
+    const { page = '1', pageSize = '20', groupId, locationId, search, sku, gender, size, color } = req.query || {};
     const pageNumber = Math.max(parseInt(page, 10) || 1, 1);
     const limit = Math.min(Math.max(parseInt(pageSize, 10) || 20, 1), 200);
     const filter = { deletedAt: null };
@@ -541,6 +541,13 @@ router.get(
         return res.json({ total: 0, page: pageNumber, pageSize: limit, items: [] });
       }
       filter.group = { $in: groupFilterValues };
+    }
+    const normalizedLocationId = typeof locationId === 'string' ? locationId.trim() : '';
+    if (normalizedLocationId) {
+      if (!Types.ObjectId.isValid(normalizedLocationId)) {
+        return res.json({ total: 0, page: pageNumber, pageSize: limit, items: [] });
+      }
+      filter[`stock.${normalizedLocationId}`] = { $exists: true };
     }
     const attributeFilters = {};
     const genderFilter = buildCaseInsensitiveExactFilter(gender);

--- a/frontend/src/pages/items/ItemsPage.jsx
+++ b/frontend/src/pages/items/ItemsPage.jsx
@@ -187,7 +187,14 @@ export default function ItemsPage() {
   const [groups, setGroups] = useState([]);
   const [locations, setLocations] = useState([]);
   const [pendingSnapshot, setPendingSnapshot] = useState([]);
-  const [filters, setFilters] = useState({ search: '', groupId: '', gender: '', size: '', color: '' });
+  const [filters, setFilters] = useState({
+    search: '',
+    groupId: '',
+    locationId: '',
+    gender: '',
+    size: '',
+    color: ''
+  });
   const [formValues, setFormValues] = useState({
     code: '',
     description: '',
@@ -336,6 +343,7 @@ export default function ItemsPage() {
           pageSize,
           search: filters.search,
           groupId: filters.groupId,
+          locationId: filters.locationId,
           gender: filters.gender,
           size: filters.size,
           color: filters.color
@@ -365,6 +373,7 @@ export default function ItemsPage() {
     filters.color,
     filters.gender,
     filters.groupId,
+    filters.locationId,
     filters.search,
     filters.size,
     page,
@@ -1305,6 +1314,27 @@ export default function ItemsPage() {
                 return (
                   <option key={id || group.name} value={id}>
                     {group.name}
+                  </option>
+                );
+              })}
+            </select>
+          </div>
+          <div className="input-group">
+            <label htmlFor="filterLocation">Ubicación</label>
+            <select
+              id="filterLocation"
+              value={filters.locationId}
+              onChange={event => {
+                setFilters(prev => ({ ...prev, locationId: event.target.value }));
+                setPage(1);
+              }}
+            >
+              <option value="">Todas</option>
+              {locations.map(location => {
+                const id = getLocationId(location);
+                return (
+                  <option key={id || location.name} value={id}>
+                    {location.name}
                   </option>
                 );
               })}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -69,7 +69,13 @@ paths:
           description: No Content
   /api/items:
     get:
-      summary: List items (filters by attributes and group)
+      summary: List items (filters by attributes, group and location)
+      parameters:
+        - in: query
+          name: locationId
+          schema:
+            type: string
+          description: Return only items that have stock registered at this location
       responses:
         '200':
           description: OK


### PR DESCRIPTION
### Motivation
- Permitir filtrar la lista de artículos por la ubicación de depósito para facilitar búsquedas y revisar stock por ubicación específica.
- Hacer que la UI pueda seleccionar una ubicación y que esa selección se refleje en la consulta al endpoint de artículos.

### Description
- Frontend: se agregó el campo `locationId` al estado `filters` y un selector `Ubicación` en `frontend/src/pages/items/ItemsPage.jsx`, que reinicia la paginación al cambiar y envía `locationId` en las consultas a la API.
- Backend: se aceptó el parámetro `locationId` en `backend/src/routes/items.js`, se valida como `ObjectId` y se filtran los artículos que tienen stock registrado en la ubicación mediante `filter[
  \\`stock.${locationId}\\`] = { $exists: true }`.
- API: se documentó el nuevo parámetro `locationId` en `openapi.yaml` para indicar que la respuesta puede limitarse a artículos con stock en esa ubicación.
- Archivos modificados: `frontend/src/pages/items/ItemsPage.jsx`, `backend/src/routes/items.js`, `openapi.yaml`.

### Testing
- Se ejecutó `cd frontend && npm run build` y la compilación del frontend completó correctamente.
- Se intentó `cd frontend && npm test` pero falló debido a que el proyecto frontend no define un script `test` (error `Missing script: "test"`).
- En el backend se ejecutó `npm test` y corrió el script actual que imprime `No hay pruebas automatizadas definidas` (comando ejecutado correctamente), y además se verificó la sintaxis con `node --check src/routes/items.js` que no reportó errores.
- Se ejecutaron comprobaciones estáticas con `git diff --check` para validar cambios y no arrojaron problemas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6a108296c8832a82f4db6b529b1827)