### PR TITLE
Add location-based filtering for items (locationId) in API and UI

### DIFF
--- a/backend/src/routes/items.js
+++ b/backend/src/routes/items.js
@@ -529,7 +529,7 @@ router.get(
       await ensureItemSkus();
     }
 
-    const { page = '1', pageSize = '20', groupId, search, sku, gender, size, color } = req.query || {};
+    const { page = '1', pageSize = '20', groupId, locationId, search, sku, gender, size, color } = req.query || {};
     const pageNumber = Math.max(parseInt(page, 10) || 1, 1);
     const limit = Math.min(Math.max(parseInt(pageSize, 10) || 20, 1), 200);
     const filter = { deletedAt: null };
@@ -541,6 +541,13 @@ router.get(
         return res.json({ total: 0, page: pageNumber, pageSize: limit, items: [] });
       }
       filter.group = { $in: groupFilterValues };
+    }
+    const normalizedLocationId = typeof locationId === 'string' ? locationId.trim() : '';
+    if (normalizedLocationId) {
+      if (!Types.ObjectId.isValid(normalizedLocationId)) {
+        return res.json({ total: 0, page: pageNumber, pageSize: limit, items: [] });
+      }
+      filter[`stock.${normalizedLocationId}`] = { $exists: true };
     }
     const attributeFilters = {};
     const genderFilter = buildCaseInsensitiveExactFilter(gender);

--- a/frontend/src/pages/items/ItemsPage.jsx
+++ b/frontend/src/pages/items/ItemsPage.jsx
@@ -187,7 +187,14 @@ export default function ItemsPage() {
   const [groups, setGroups] = useState([]);
   const [locations, setLocations] = useState([]);
   const [pendingSnapshot, setPendingSnapshot] = useState([]);
-  const [filters, setFilters] = useState({ search: '', groupId: '', gender: '', size: '', color: '' });
+  const [filters, setFilters] = useState({
+    search: '',
+    groupId: '',
+    locationId: '',
+    gender: '',
+    size: '',
+    color: ''
+  });
   const [formValues, setFormValues] = useState({
     code: '',
     description: '',
@@ -336,6 +343,7 @@ export default function ItemsPage() {
           pageSize,
           search: filters.search,
           groupId: filters.groupId,
+          locationId: filters.locationId,
           gender: filters.gender,
           size: filters.size,
           color: filters.color
@@ -365,6 +373,7 @@ export default function ItemsPage() {
     filters.color,
     filters.gender,
     filters.groupId,
+    filters.locationId,
     filters.search,
     filters.size,
     page,
@@ -1362,6 +1371,27 @@ export default function ItemsPage() {
                   {option}
                 </option>
               ))}
+            </select>
+          </div>
+          <div className="input-group">
+            <label htmlFor="filterLocation">Ubicación de stock</label>
+            <select
+              id="filterLocation"
+              value={filters.locationId}
+              onChange={event => {
+                setFilters(prev => ({ ...prev, locationId: event.target.value }));
+                setPage(1);
+              }}
+            >
+              <option value="">Todas</option>
+              {locations.map(location => {
+                const id = getLocationId(location);
+                return (
+                  <option key={id || location.name} value={id}>
+                    {location.name}
+                  </option>
+                );
+              })}
             </select>
           </div>
         </form>

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -69,7 +69,13 @@ paths:
           description: No Content
   /api/items:
     get:
-      summary: List items (filters by attributes and group)
+      summary: List items (filters by attributes, group and location)
+      parameters:
+        - in: query
+          name: locationId
+          schema:
+            type: string
+          description: Return only items that have stock registered at this location
       responses:
         '200':
           description: OK


### PR DESCRIPTION
### Motivation
- Allow users to filter items by a specific stock location so the item list can show only items that have stock registered at that location.
- Surface the new filter in the UI so users can select a location when browsing items.

### Description
- Add `locationId` query parameter handling to the items API endpoint and validate it with `Types.ObjectId.isValid` before applying a filter that checks for `stock.<locationId>` existence.
- Extend the frontend `ItemsPage` to include `locationId` in `filters`, send it in the `/items` request query, add it to effect dependencies, and render a new select input for choosing a location.
- Update `openapi.yaml` to document the new `locationId` query parameter and update the `/api/items` summary to mention location filtering.

### Testing
- Ran the backend test suite and API validation, which completed successfully with no failures.
- Ran the frontend unit tests and component tests, which passed successfully.
- Validated the OpenAPI spec changes with the project API linter, which reported no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6a108296c8832a82f4db6b529b1827)