### PR TITLE
Add location filter to items (API + UI), update OpenAPI, add frontend deploy script and docs

### DIFF
--- a/backend/src/routes/items.js
+++ b/backend/src/routes/items.js
@@ -529,7 +529,7 @@ router.get(
       await ensureItemSkus();
     }
 
-    const { page = '1', pageSize = '20', groupId, search, sku, gender, size, color } = req.query || {};
+    const { page = '1', pageSize = '20', groupId, locationId, search, sku, gender, size, color } = req.query || {};
     const pageNumber = Math.max(parseInt(page, 10) || 1, 1);
     const limit = Math.min(Math.max(parseInt(pageSize, 10) || 20, 1), 200);
     const filter = { deletedAt: null };
@@ -541,6 +541,13 @@ router.get(
         return res.json({ total: 0, page: pageNumber, pageSize: limit, items: [] });
       }
       filter.group = { $in: groupFilterValues };
+    }
+    const normalizedLocationId = typeof locationId === 'string' ? locationId.trim() : '';
+    if (normalizedLocationId) {
+      if (!Types.ObjectId.isValid(normalizedLocationId)) {
+        return res.json({ total: 0, page: pageNumber, pageSize: limit, items: [] });
+      }
+      filter[`stock.${normalizedLocationId}`] = { $exists: true };
     }
     const attributeFilters = {};
     const genderFilter = buildCaseInsensitiveExactFilter(gender);

--- a/docs/demo-deployment.md
+++ b/docs/demo-deployment.md
@@ -163,6 +163,25 @@ Si ya tienes una copia, actualízala con `git pull`.
    - El sitio estará disponible en `http://<IP_DE_LA_MAQUINA>:4173`.
    - Si prefieres un entorno de desarrollo rápido, usa `npm run dev -- --host` (no recomendado para demos públicas).
 
+### Actualizar el frontend en producción
+
+Un `git pull` solo actualiza el código fuente: la interfaz publicada no cambia hasta volver a generar los archivos estáticos. Desde la raíz del repositorio, después de traer el commit, ejecuta:
+
+```bash
+git pull
+./scripts/deploy_frontend_production.sh
+```
+
+El script instala las dependencias, ejecuta la compilación y comprueba que el bundle generado contiene el filtro **Ubicación**. Si el frontend se ejecuta mediante un proceso PM2 llamado `gestionthibe-frontend`, también lo reinicia; si Nginx sirve `frontend/dist` directamente, no hace falta reiniciar el backend.
+
+Si el proceso PM2 tiene otro nombre, indícalo al ejecutar el script:
+
+```bash
+FRONTEND_PM2_NAME=nombre-real ./scripts/deploy_frontend_production.sh
+```
+
+Finalmente, recarga la página con `Ctrl+F5` o abre una ventana privada para descartar el documento HTML anterior almacenado por el navegador.
+
 ## 6. Verificar el funcionamiento
 
 1. Abre el navegador y navega a `http://<IP_DE_LA_MAQUINA>:4173`.

--- a/frontend/src/pages/items/ItemsPage.jsx
+++ b/frontend/src/pages/items/ItemsPage.jsx
@@ -187,7 +187,14 @@ export default function ItemsPage() {
   const [groups, setGroups] = useState([]);
   const [locations, setLocations] = useState([]);
   const [pendingSnapshot, setPendingSnapshot] = useState([]);
-  const [filters, setFilters] = useState({ search: '', groupId: '', gender: '', size: '', color: '' });
+  const [filters, setFilters] = useState({
+    search: '',
+    groupId: '',
+    locationId: '',
+    gender: '',
+    size: '',
+    color: ''
+  });
   const [formValues, setFormValues] = useState({
     code: '',
     description: '',
@@ -336,6 +343,7 @@ export default function ItemsPage() {
           pageSize,
           search: filters.search,
           groupId: filters.groupId,
+          locationId: filters.locationId,
           gender: filters.gender,
           size: filters.size,
           color: filters.color
@@ -365,6 +373,7 @@ export default function ItemsPage() {
     filters.color,
     filters.gender,
     filters.groupId,
+    filters.locationId,
     filters.search,
     filters.size,
     page,
@@ -1305,6 +1314,27 @@ export default function ItemsPage() {
                 return (
                   <option key={id || group.name} value={id}>
                     {group.name}
+                  </option>
+                );
+              })}
+            </select>
+          </div>
+          <div className="input-group">
+            <label htmlFor="filterLocation">Ubicación</label>
+            <select
+              id="filterLocation"
+              value={filters.locationId}
+              onChange={event => {
+                setFilters(prev => ({ ...prev, locationId: event.target.value }));
+                setPage(1);
+              }}
+            >
+              <option value="">Todas</option>
+              {locations.map(location => {
+                const id = getLocationId(location);
+                return (
+                  <option key={id || location.name} value={id}>
+                    {location.name}
                   </option>
                 );
               })}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -69,7 +69,13 @@ paths:
           description: No Content
   /api/items:
     get:
-      summary: List items (filters by attributes and group)
+      summary: List items (filters by attributes, group and location)
+      parameters:
+        - in: query
+          name: locationId
+          schema:
+            type: string
+          description: Return only items that have stock registered at this location
       responses:
         '200':
           description: OK

--- a/scripts/deploy_frontend_production.sh
+++ b/scripts/deploy_frontend_production.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+APP_DIR="${APP_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+FRONTEND_DIR="$APP_DIR/frontend"
+FRONTEND_PM2_NAME="${FRONTEND_PM2_NAME:-gestionthibe-frontend}"
+
+log() {
+  printf '[frontend-deploy] %s\n' "$*"
+}
+
+if [[ ! -f "$FRONTEND_DIR/package.json" ]]; then
+  echo "No se encontró el frontend en $FRONTEND_DIR" >&2
+  exit 1
+fi
+
+log "Instalando dependencias..."
+(cd "$FRONTEND_DIR" && npm install)
+
+log "Generando los archivos estáticos de producción..."
+(cd "$FRONTEND_DIR" && npm run build)
+
+if ! grep -Rqs --include='*.js' 'filterLocation' "$FRONTEND_DIR/dist" "$FRONTEND_DIR/build" 2>/dev/null; then
+  echo 'La compilación no contiene el filtro "Ubicación".' >&2
+  exit 1
+fi
+
+log 'Compilación verificada: el filtro "Ubicación" está incluido.'
+
+if command -v pm2 >/dev/null 2>&1 && pm2 describe "$FRONTEND_PM2_NAME" >/dev/null 2>&1; then
+  log "Reiniciando el frontend administrado por PM2 ($FRONTEND_PM2_NAME)..."
+  pm2 restart "$FRONTEND_PM2_NAME" --update-env
+else
+  log "No se encontró el proceso PM2 $FRONTEND_PM2_NAME; no es necesario reiniciar si Nginx sirve frontend/dist directamente."
+fi
+
+log 'Despliegue terminado. Actualizá el navegador con Ctrl+F5.'


### PR DESCRIPTION
### Motivation
- Allow filtering catalog items by presence of stock at a specific location so users can scope lists to a physical site. 
- Expose the new `locationId` filter in the frontend UI and ensure the backend validates and applies it efficiently. 
- Provide a small deployment helper and docs to simplify updating the frontend assets in production.

### Description
- Backend `GET /api/items` now accepts a `locationId` query parameter, validates it with `Types.ObjectId.isValid`, and filters items by presence of `stock.{locationId}` (`$exists: true`).
- Frontend `ItemsPage` adds `locationId` to the `filters` state, includes it in the API query, adds the select control to the UI, and wires it into the effect dependencies so lists refresh when the location changes.
- `openapi.yaml` updated to document the `locationId` query parameter for `GET /api/items` with a brief description. 
- Added `scripts/deploy_frontend_production.sh` to automate installing deps, building the frontend, verifying the compiled bundle contains the "Ubicación" filter, and optionally restarting a PM2-managed frontend process; docs (`docs/demo-deployment.md`) include instructions to use the script.

### Testing
- Executed the frontend production deployment script `./scripts/deploy_frontend_production.sh` locally, which runs `npm install` and `npm run build` and verifies the compiled bundle contains the filter text; the script completed and verification succeeded.
- No changes were made to existing automated backend test suites in this PR and no new unit tests were added.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6a108296c8832a82f4db6b529b1827)