### PR TITLE
Filter items by location (backend + frontend); add build-time check and deploy script

### DIFF
--- a/backend/src/routes/items.js
+++ b/backend/src/routes/items.js
@@ -529,7 +529,7 @@ router.get(
       await ensureItemSkus();
     }
 
-    const { page = '1', pageSize = '20', groupId, search, sku, gender, size, color } = req.query || {};
+    const { page = '1', pageSize = '20', groupId, locationId, search, sku, gender, size, color } = req.query || {};
     const pageNumber = Math.max(parseInt(page, 10) || 1, 1);
     const limit = Math.min(Math.max(parseInt(pageSize, 10) || 20, 1), 200);
     const filter = { deletedAt: null };
@@ -541,6 +541,13 @@ router.get(
         return res.json({ total: 0, page: pageNumber, pageSize: limit, items: [] });
       }
       filter.group = { $in: groupFilterValues };
+    }
+    const normalizedLocationId = typeof locationId === 'string' ? locationId.trim() : '';
+    if (normalizedLocationId) {
+      if (!Types.ObjectId.isValid(normalizedLocationId)) {
+        return res.json({ total: 0, page: pageNumber, pageSize: limit, items: [] });
+      }
+      filter[`stock.${normalizedLocationId}`] = { $exists: true };
     }
     const attributeFilters = {};
     const genderFilter = buildCaseInsensitiveExactFilter(gender);

--- a/docs/demo-deployment.md
+++ b/docs/demo-deployment.md
@@ -163,6 +163,25 @@ Si ya tienes una copia, actualízala con `git pull`.
    - El sitio estará disponible en `http://<IP_DE_LA_MAQUINA>:4173`.
    - Si prefieres un entorno de desarrollo rápido, usa `npm run dev -- --host` (no recomendado para demos públicas).
 
+### Actualizar el frontend en producción
+
+Un `git pull` solo actualiza el código fuente: la interfaz publicada no cambia hasta volver a generar los archivos estáticos. Desde la raíz del repositorio, después de traer el commit, ejecuta:
+
+```bash
+git pull
+./scripts/deploy_frontend_production.sh
+```
+
+El script instala las dependencias, ejecuta la compilación y comprueba que el bundle generado contiene un único filtro **Ubicación** y que ya no contiene el texto anterior **Ubicación de stock**. Si el frontend se ejecuta mediante un proceso PM2 llamado `gestionthibe-frontend`, también lo reinicia; si Nginx sirve `frontend/dist` directamente, no hace falta reiniciar el backend.
+
+Si el proceso PM2 tiene otro nombre, indícalo al ejecutar el script:
+
+```bash
+FRONTEND_PM2_NAME=nombre-real ./scripts/deploy_frontend_production.sh
+```
+
+Finalmente, recarga la página con `Ctrl+F5` o abre una ventana privada para descartar el documento HTML anterior almacenado por el navegador.
+
 ## 6. Verificar el funcionamiento
 
 1. Abre el navegador y navega a `http://<IP_DE_LA_MAQUINA>:4173`.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "node scripts/build.mjs",
+    "build": "npm run check:items-location-filter && node scripts/build.mjs",
+    "check:items-location-filter": "node scripts/check-items-location-filter.mjs",
     "clean": "node scripts/clean-dist.mjs",
     "rebuild": "npm run clean && npm run build",
     "preview": "node scripts/preview.mjs",

--- a/frontend/scripts/check-items-location-filter.mjs
+++ b/frontend/scripts/check-items-location-filter.mjs
@@ -1,0 +1,20 @@
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+const itemsPagePath = resolve('src/pages/items/ItemsPage.jsx');
+const source = await readFile(itemsPagePath, 'utf8');
+const locationFilterLabels = source.match(/<label htmlFor="filterLocation">/g) ?? [];
+
+if (locationFilterLabels.length !== 1) {
+  console.error(
+    `[check-items-location-filter] Se esperaba un único filtro de ubicación, pero se encontraron ${locationFilterLabels.length}.`
+  );
+  process.exit(1);
+}
+
+if (source.includes('Ubicación de stock')) {
+  console.error('[check-items-location-filter] Todavía existe el filtro duplicado "Ubicación de stock".');
+  process.exit(1);
+}
+
+console.log('[check-items-location-filter] OK: existe un único filtro "Ubicación".');

--- a/frontend/src/pages/items/ItemsPage.jsx
+++ b/frontend/src/pages/items/ItemsPage.jsx
@@ -187,7 +187,14 @@ export default function ItemsPage() {
   const [groups, setGroups] = useState([]);
   const [locations, setLocations] = useState([]);
   const [pendingSnapshot, setPendingSnapshot] = useState([]);
-  const [filters, setFilters] = useState({ search: '', groupId: '', gender: '', size: '', color: '' });
+  const [filters, setFilters] = useState({
+    search: '',
+    groupId: '',
+    locationId: '',
+    gender: '',
+    size: '',
+    color: ''
+  });
   const [formValues, setFormValues] = useState({
     code: '',
     description: '',
@@ -336,6 +343,7 @@ export default function ItemsPage() {
           pageSize,
           search: filters.search,
           groupId: filters.groupId,
+          locationId: filters.locationId,
           gender: filters.gender,
           size: filters.size,
           color: filters.color
@@ -365,6 +373,7 @@ export default function ItemsPage() {
     filters.color,
     filters.gender,
     filters.groupId,
+    filters.locationId,
     filters.search,
     filters.size,
     page,
@@ -1305,6 +1314,27 @@ export default function ItemsPage() {
                 return (
                   <option key={id || group.name} value={id}>
                     {group.name}
+                  </option>
+                );
+              })}
+            </select>
+          </div>
+          <div className="input-group">
+            <label htmlFor="filterLocation">Ubicación</label>
+            <select
+              id="filterLocation"
+              value={filters.locationId}
+              onChange={event => {
+                setFilters(prev => ({ ...prev, locationId: event.target.value }));
+                setPage(1);
+              }}
+            >
+              <option value="">Todas</option>
+              {locations.map(location => {
+                const id = getLocationId(location);
+                return (
+                  <option key={id || location.name} value={id}>
+                    {location.name}
                   </option>
                 );
               })}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -69,7 +69,13 @@ paths:
           description: No Content
   /api/items:
     get:
-      summary: List items (filters by attributes and group)
+      summary: List items (filters by attributes, group and location)
+      parameters:
+        - in: query
+          name: locationId
+          schema:
+            type: string
+          description: Return only items that have stock registered at this location
       responses:
         '200':
           description: OK

--- a/scripts/deploy_frontend_production.sh
+++ b/scripts/deploy_frontend_production.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+APP_DIR="${APP_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+FRONTEND_DIR="$APP_DIR/frontend"
+FRONTEND_PM2_NAME="${FRONTEND_PM2_NAME:-gestionthibe-frontend}"
+
+log() {
+  printf '[frontend-deploy] %s\n' "$*"
+}
+
+if [[ ! -f "$FRONTEND_DIR/package.json" ]]; then
+  echo "No se encontró el frontend en $FRONTEND_DIR" >&2
+  exit 1
+fi
+
+log "Instalando dependencias..."
+(cd "$FRONTEND_DIR" && npm install)
+
+log "Generando los archivos estáticos de producción..."
+(cd "$FRONTEND_DIR" && npm run build)
+
+if ! grep -Rqs --include='*.js' 'filterLocation' "$FRONTEND_DIR/dist" "$FRONTEND_DIR/build" 2>/dev/null; then
+  echo 'La compilación no contiene el filtro "Ubicación".' >&2
+  exit 1
+fi
+
+if grep -Rqs --include='*.js' 'Ubicación de stock' "$FRONTEND_DIR/dist" "$FRONTEND_DIR/build" 2>/dev/null; then
+  echo 'La compilación todavía contiene el filtro duplicado "Ubicación de stock".' >&2
+  exit 1
+fi
+
+log 'Compilación verificada: el filtro "Ubicación" está incluido.'
+log 'Compilación verificada: el filtro duplicado "Ubicación de stock" no existe.'
+
+if command -v pm2 >/dev/null 2>&1 && pm2 describe "$FRONTEND_PM2_NAME" >/dev/null 2>&1; then
+  log "Reiniciando el frontend administrado por PM2 ($FRONTEND_PM2_NAME)..."
+  pm2 restart "$FRONTEND_PM2_NAME" --update-env
+else
+  log "No se encontró el proceso PM2 $FRONTEND_PM2_NAME; no es necesario reiniciar si Nginx sirve frontend/dist directamente."
+fi
+
+log 'Despliegue terminado. Actualizá el navegador con Ctrl+F5.'


### PR DESCRIPTION
### Motivation

- Allow listing items filtered by a specific location so the UI can show only items that have stock at that location.
- Replace a duplicated "Ubicación de stock" filter with a single "Ubicación" filter in the frontend UI and prevent regressions via an automated check.
- Provide a simple production frontend deployment script that rebuilds the frontend, verifies the expected bundle contents, and optionally restarts a PM2 process.

### Description

- Backend: updated `GET /api/items` in `backend/src/routes/items.js` to accept `locationId` from the query string, validate it with `Types.ObjectId.isValid`, and filter items by `stock.<locationId>` existence.
- OpenAPI: documented the new `locationId` query parameter in `openapi.yaml` for `GET /api/items` with a short description.
- Frontend: added `locationId` to the `filters` state in `frontend/src/pages/items/ItemsPage.jsx`, included it in the query sent to `/items`, added it to the effect dependency list, and added a select input to the UI for choosing a location.
- Build and verification: added `frontend/scripts/check-items-location-filter.mjs` which enforces a single `filterLocation` label and the absence of the old "Ubicación de stock" text, and wired it into `frontend/package.json` as the `check:items-location-filter` script executed before `build`.
- Deployment: added `scripts/deploy_frontend_production.sh` which runs `npm install` and `npm run build`, verifies the compiled bundle contains the `filterLocation` marker and not the old duplicated label, and restarts a PM2-managed frontend process if present.
- Docs: updated `docs/demo-deployment.md` with instructions to use the new deployment script and its expected checks.

### Testing

- Ran the frontend source check with `node frontend/scripts/check-items-location-filter.mjs`, which passed and printed a success message.
- Executed `npm run build` in the `frontend` directory (which runs the check as part of the build), and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6a108296c8832a82f4db6b529b1827)