### PR TITLE
Restaurar acceso directo a /login y eliminar filtro de ubicación duplicado

### DIFF
--- a/frontend/src/pages/items/ItemsPage.jsx
+++ b/frontend/src/pages/items/ItemsPage.jsx
@@ -1394,27 +1394,6 @@ export default function ItemsPage() {
               ))}
             </select>
           </div>
-          <div className="input-group">
-            <label htmlFor="filterLocation">Ubicación de stock</label>
-            <select
-              id="filterLocation"
-              value={filters.locationId}
-              onChange={event => {
-                setFilters(prev => ({ ...prev, locationId: event.target.value }));
-                setPage(1);
-              }}
-            >
-              <option value="">Todas</option>
-              {locations.map(location => {
-                const id = getLocationId(location);
-                return (
-                  <option key={id || location.name} value={id}>
-                    {location.name}
-                  </option>
-                );
-              })}
-            </select>
-          </div>
         </form>
 
         {loading ? (

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -2,6 +2,9 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
 export default defineConfig({
+  // React Router resuelve rutas como /login en el navegador. Vite debe
+  // devolver index.html también cuando esas rutas se abren directamente.
+  appType: 'spa',
   plugins: [react()],
   server: {
     host: '0.0.0.0',


### PR DESCRIPTION
### Motivation
- Navegar directamente a `/#/login` o `/login` devolvía error porque Vite no estaba configurado como SPA y no servía `index.html` para rutas manejadas por React Router.
- La compilación de producción fallaba la verificación previa porque existía un filtro de ubicación duplicado en la vista de artículos, bloqueando el despliegue.

### Description
- Configura Vite como aplicación SPA añadiendo `appType: 'spa'` en `frontend/vite.config.js` para que las rutas de React Router devuelvan `index.html` al acceder directamente.
- Elimina el filtro duplicado `Ubicación de stock` en `frontend/src/pages/items/ItemsPage.jsx`, dejando un único filtro `Ubicación` y manteniendo el uso de `filters.locationId`.

### Testing
- Ejecuté `npm run build` en `frontend` y la comprobación `check-items-location-filter` pasó correctamente y la compilación final fue exitosa.
- Inicié `npm run preview` y verifiqué con `curl` que `/` y `/login` responden `200` y que ambos sirven el mismo `index.html` (comparación con `cmp`).
- Ejecuté `git diff --check` para validar que no quedan errores de formato o chequeos automáticos y la verificación fue satisfactoria.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6a5d4cfed0832ab5f65af567c05b73)