### PR TITLE
Add 'Artículos Locales' section (filter items by locations marked Local)

### DIFF
--- a/backend/src/models/Location.js
+++ b/backend/src/models/Location.js
@@ -9,6 +9,7 @@ const locationSchema = new Schema(
     description: { type: String, default: '' },
     contactInfo: { type: String, default: '' },
     shopifyLocationId: { type: String, default: null, trim: true, index: true },
+    isLocal: { type: Boolean, default: false },
     status: { type: String, enum: ['active', 'inactive'], default: 'active' }
   },
   {

--- a/backend/src/routes/locations.js
+++ b/backend/src/routes/locations.js
@@ -19,12 +19,30 @@ function serializeLocation(location) {
     description: location.description || '',
     contactInfo: location.contactInfo || '',
     shopifyLocationId: location.shopifyLocationId || '',
-    status: location.status
+    status: location.status,
+    isLocal: Boolean(location.isLocal)
   };
 }
 
 function sanitizeOptionalString(value) {
   return typeof value === 'string' ? value.trim() : '';
+}
+
+function normalizeLocalFlag(value) {
+  if (value === undefined || value === null) {
+    return false;
+  }
+  if (typeof value === 'boolean') {
+    return value;
+  }
+  if (typeof value === 'number') {
+    return value === 1;
+  }
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    return ['s', 'si', 'sí', 'true', '1', 'yes', 'y', 'on'].includes(normalized);
+  }
+  return false;
 }
 
 function ensureValidType(type) {
@@ -59,7 +77,7 @@ router.post(
   '/',
   requirePermission('items.write'),
   asyncHandler(async (req, res) => {
-    const { name, description, contactInfo, shopifyLocationId, status, type } = req.body || {};
+    const { name, description, contactInfo, shopifyLocationId, status, type, isLocal } = req.body || {};
     if (!name || typeof name !== 'string' || !name.trim()) {
       throw new HttpError(400, 'El nombre es obligatorio');
     }
@@ -69,6 +87,7 @@ router.post(
       description: sanitizeOptionalString(description),
       contactInfo: sanitizeOptionalString(contactInfo),
       shopifyLocationId: sanitizeOptionalString(shopifyLocationId) || null,
+      isLocal: normalizeLocalFlag(isLocal),
       status: status === 'inactive' ? 'inactive' : 'active'
     });
     res.status(201).json(serializeLocation(location));
@@ -84,7 +103,7 @@ router.put(
     if (!location) {
       throw new HttpError(404, 'Ubicación no encontrada');
     }
-    const { name, description, contactInfo, shopifyLocationId, status, type } = req.body || {};
+    const { name, description, contactInfo, shopifyLocationId, status, type, isLocal } = req.body || {};
     if (name !== undefined) {
       if (typeof name !== 'string' || !name.trim()) {
         throw new HttpError(400, 'El nombre es obligatorio');
@@ -102,6 +121,9 @@ router.put(
     }
     if (shopifyLocationId !== undefined) {
       location.shopifyLocationId = sanitizeOptionalString(shopifyLocationId) || null;
+    }
+    if (isLocal !== undefined) {
+      location.isLocal = normalizeLocalFlag(isLocal);
     }
     if (status !== undefined) {
       if (!['active', 'inactive'].includes(status)) {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -33,6 +33,7 @@ export default function App() {
         <Route index element={<DashboardPage />} />
         <Route path="inventory/alerts" element={<InventoryAlertsPage />} />
         <Route path="items" element={<ItemsPage />} />
+        <Route path="items/local" element={<ItemsPage localOnly />} />
         <Route path="overstock" element={<OverstockPage />} />
         <Route path="items/barcode-reception" element={<BarcodeReceptionPage />} />
         <Route path="items/download" element={<ItemsDownloadPage />} />

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -4,6 +4,7 @@ import { useAuth } from '../context/AuthContext.jsx';
 const NAV_ITEMS = [
   { to: '/', label: 'Resumen' },
   { to: '/items', label: 'Artículos', permission: 'items.read', hiddenForRoles: ['Operador'] },
+  { to: '/items/local', label: 'Artículos Locales', permission: 'items.read', hiddenForRoles: ['Operador'] },
   { to: '/items/barcode-reception', label: 'Escaneo de Productos', permissionsAny: ['stock.approve', 'stock.request'] },
   { to: '/overstock', label: 'Sobrestock', permission: 'items.read', hiddenForRoles: ['Operador'] },
   { to: '/items/trash', label: 'Papelera', permission: 'items.write', hiddenForRoles: ['Operador'] },

--- a/frontend/src/pages/items/ItemsPage.jsx
+++ b/frontend/src/pages/items/ItemsPage.jsx
@@ -166,7 +166,7 @@ function fileToDataUrl(file) {
   });
 }
 
-export default function ItemsPage() {
+export default function ItemsPage({ localOnly = false } = {}) {
   const api = useApi();
   const routeLocation = useLocation();
   const navigate = useNavigate();
@@ -293,7 +293,7 @@ export default function ItemsPage() {
         setLocations(
           Array.isArray(locationsResponse)
             ? [...locationsResponse]
-                .filter(location => location.type === 'warehouse')
+                .filter(location => location.type === 'warehouse' && (!localOnly || location.isLocal))
                 .sort((a, b) => a.name.localeCompare(b.name, 'es', { sensitivity: 'base' }))
             : []
         );
@@ -305,7 +305,7 @@ export default function ItemsPage() {
     return () => {
       active = false;
     };
-  }, [api, sortGroupsByName]);
+  }, [api, localOnly, sortGroupsByName]);
 
   useEffect(() => {
     let active = true;
@@ -819,9 +819,9 @@ export default function ItemsPage() {
     }
     openedExternalEditRef.current = requestedItem.id;
     handleEdit(requestedItem);
-    navigate('/items', { replace: true, state: null });
+    navigate(localOnly ? '/items/local' : '/items', { replace: true, state: null });
     window.requestAnimationFrame(() => window.scrollTo({ top: 0, behavior: 'smooth' }));
-  }, [canWrite, navigate, routeLocation.state]);
+  }, [canWrite, localOnly, navigate, routeLocation.state]);
 
   const handleDelete = async item => {
     if (!item) return;
@@ -897,9 +897,11 @@ export default function ItemsPage() {
     <div>
       <div className="flex-between">
         <div>
-          <h2>Gestión de artículos</h2>
+          <h2>{localOnly ? 'Artículos en locales' : 'Gestión de artículos'}</h2>
           <p style={{ color: '#475569', marginTop: '-0.4rem' }}>
-            Administre la taxonomía, atributos y stock distribuido por ubicación para cada artículo.
+            {localOnly
+              ? 'Administre artículos mostrando únicamente el stock cargado en ubicaciones marcadas como Local.'
+              : 'Administre la taxonomía, atributos y stock distribuido por ubicación para cada artículo.'}
           </p>
         </div>
         <div className="inline-actions">
@@ -1274,7 +1276,9 @@ export default function ItemsPage() {
             <div>
               <h2>Consulta de artículos</h2>
               <p style={{ color: '#475569', margin: 0 }}>
-                Tu rol permite buscar datos, revisar cantidades e imágenes, pero no crear, editar ni eliminar artículos.
+                {localOnly
+                  ? 'Tu rol permite consultar artículos y revisar únicamente cantidades de ubicaciones marcadas como Local.'
+                  : 'Tu rol permite buscar datos, revisar cantidades e imágenes, pero no crear, editar ni eliminar artículos.'}
               </p>
             </div>
           </div>
@@ -1283,7 +1287,7 @@ export default function ItemsPage() {
 
       <div className="section-card">
         <div className="flex-between">
-          <h2>Buscar artículos</h2>
+          <h2>{localOnly ? 'Buscar artículos en locales' : 'Buscar artículos'}</h2>
         </div>
         <form className="form-grid" style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))' }}>
           <div className="input-group">

--- a/frontend/src/pages/locations/LocationsPage.jsx
+++ b/frontend/src/pages/locations/LocationsPage.jsx
@@ -10,6 +10,7 @@ const INITIAL_FORM_STATE = {
   description: '',
   contactInfo: '',
   shopifyLocationId: '',
+  isLocal: false,
   status: 'active'
 };
 
@@ -55,6 +56,7 @@ export default function LocationsPage() {
       description: location.description || '',
       contactInfo: location.contactInfo || '',
       shopifyLocationId: location.shopifyLocationId || '',
+      isLocal: Boolean(location.isLocal),
       status: location.status === 'inactive' ? 'inactive' : 'active'
     };
   };
@@ -93,7 +95,7 @@ export default function LocationsPage() {
     };
   }, [api, canRead]);
 
-  const locationsTableColSpan = 6 + (canWrite ? 1 : 0);
+  const locationsTableColSpan = 7 + (canWrite ? 1 : 0);
 
   const filteredLocations = useMemo(() => {
     if (filterType === 'all') {
@@ -103,9 +105,9 @@ export default function LocationsPage() {
   }, [filterType, locations]);
 
   const handleFormChange = event => {
-    const { name, value } = event.target;
+    const { name, type, checked, value } = event.target;
     setSuccessMessage('');
-    setFormValues(prev => ({ ...prev, [name]: value }));
+    setFormValues(prev => ({ ...prev, [name]: type === 'checkbox' ? checked : value }));
   };
 
   const handleCreateNew = () => {
@@ -123,6 +125,7 @@ export default function LocationsPage() {
       description: location.description,
       contactInfo: location.contactInfo,
       shopifyLocationId: location.shopifyLocationId || '',
+      isLocal: Boolean(location.isLocal),
       status: location.status
     });
     setSuccessMessage('');
@@ -244,6 +247,7 @@ export default function LocationsPage() {
                 <th>Descripción</th>
                 <th>Contacto</th>
                 <th>Estado</th>
+                <th>Local</th>
                 <th>Shopify</th>
                 {canWrite && <th>Acciones</th>}
               </tr>
@@ -262,6 +266,7 @@ export default function LocationsPage() {
                       {location.status}
                     </span>
                   </td>
+                  <td>{location.isLocal ? 'S' : 'N'}</td>
                   <td>{location.shopifyLocationId || '-'}</td>
                   {canWrite && (
                     <td>
@@ -352,6 +357,19 @@ export default function LocationsPage() {
                 onChange={handleFormChange}
                 placeholder="Ej: 123456789 o gid://shopify/Location/123456789"
               />
+            </div>
+            <div className="input-group">
+              <label htmlFor="locationLocal">Local (S/N)</label>
+              <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+                <input
+                  id="locationLocal"
+                  name="isLocal"
+                  type="checkbox"
+                  checked={Boolean(formValues.isLocal)}
+                  onChange={handleFormChange}
+                />
+                <span>{formValues.isLocal ? 'S' : 'N'}</span>
+              </div>
             </div>
             <div className="input-group">
               <label htmlFor="locationContact">Contacto</label>


### PR DESCRIPTION
### Motivation
- Agregar una vista que muestre el mismo contenido de la sección de artículos pero limitada a los stocks de las ubicaciones marcadas como Local (S/N). 

### Description
- Añadido el campo booleano `isLocal` al modelo `Location` y expuesto en la serialización de la API de ubicaciones. 
- La API de ubicaciones ahora acepta y normaliza la bandera `isLocal` al crear/actualizar ubicaciones mediante una función `normalizeLocalFlag`. 
- La página de Ubicaciones (`LocationsPage`) muestra y permite editar el campo “Local (S/N)” en el listado y en el formulario. 
- Se añadió la ruta `/items/local` y un ítem de menú «Artículos Locales», reutilizando `ItemsPage` con la nueva prop `localOnly` para filtrar ubicaciones `warehouse` que además tengan `isLocal === true`. 

### Testing
- Ejecutado `npm --prefix frontend run build` y la construcción del frontend completó correctamente. 
- Ejecutado `npm --prefix backend test` que corre el script de pruebas (placeholder) y finalizó correctamente. 
- Ejecutado `node --check backend/src/routes/locations.js && node --check backend/src/models/Location.js` y ambos archivos pasaron la verificación de sintaxis.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a732b76abdc832a9c4c1ba40e9e71ea)