### PR TITLE
Convertir cajas a unidades al enviar a ubicaciones locales y ocultar toggle en Items

### DIFF
--- a/backend/src/routes/stock.js
+++ b/backend/src/routes/stock.js
@@ -15,6 +15,7 @@ const {
   addMovementLog,
   findItemOrThrow,
   ensureLocationExists,
+  normalizeQuantityForLocalDestination,
   normalizeStoredQuantity
 } = require('../services/stockService');
 const { recordAuditEvent } = require('../services/auditService');
@@ -460,7 +461,6 @@ router.post(
   asyncHandler(async (req, res) => {
     const body = req.body || {};
     const { quantity, fromLocation, toLocation } = await validateMovementPayload(body);
-    await findItemOrThrow(body.itemId);
 
     const movementType = determineMovementType(fromLocation, toLocation);
 
@@ -596,7 +596,8 @@ router.post(
     const created = [];
     for (const [index, line] of lines.entries()) {
       const item = await findItemOrThrow(line.itemId);
-      const quantity = normalizeQuantityInput(line.quantity, { fieldName: `Cantidad del renglón ${index + 1}` });
+      const inputQuantity = normalizeQuantityInput(line.quantity, { fieldName: `Cantidad del renglón ${index + 1}` });
+      const quantity = normalizeQuantityForLocalDestination(inputQuantity, item, toLocation);
       const movementRequest = new MovementRequest({
         item: item.id,
         type: 'ingress',

--- a/backend/src/services/stockService.js
+++ b/backend/src/services/stockService.js
@@ -75,6 +75,22 @@ function isZeroQuantity(quantity) {
   return quantity.boxes === 0 && quantity.units === 0;
 }
 
+function normalizeQuantityForLocalDestination(quantity, item, toLocation) {
+  if (!toLocation?.isLocal || quantity.boxes === 0) {
+    return quantity;
+  }
+
+  const unitsPerBox = Number(item?.unitsPerBox);
+  if (!Number.isFinite(unitsPerBox) || unitsPerBox <= 0) {
+    throw new HttpError(400, 'Hay que cargar unidades por caja para este artículo antes de enviarlo a una ubicación local');
+  }
+
+  return {
+    boxes: 0,
+    units: quantity.units + (quantity.boxes * unitsPerBox)
+  };
+}
+
 async function findItemOrThrow(itemId) {
   if (!mongoose.Types.ObjectId.isValid(itemId)) {
     throw new HttpError(404, 'Artículo no encontrado');
@@ -204,7 +220,8 @@ async function validateMovementPayload(payload) {
     throw new HttpError(400, 'No es necesario indicar el tipo de movimiento');
   }
 
-  const quantity = normalizeQuantityInput(payload.quantity, { fieldName: 'Cantidad' });
+  const inputQuantity = normalizeQuantityInput(payload.quantity, { fieldName: 'Cantidad' });
+  const item = await findItemOrThrow(payload.itemId);
 
   const fromLocationId = payload.fromLocation || payload.fromDeposit;
   const toLocationId = payload.toLocation || payload.toDeposit;
@@ -230,10 +247,13 @@ async function validateMovementPayload(payload) {
     })
   ]);
 
+  const quantity = normalizeQuantityForLocalDestination(inputQuantity, item, toLocation);
+
   return {
     quantity,
     fromLocation,
-    toLocation
+    toLocation,
+    item
   };
 }
 
@@ -244,5 +264,6 @@ module.exports = {
   findItemOrThrow,
   ensureLocationExists,
   normalizeQuantityInput,
+  normalizeQuantityForLocalDestination,
   normalizeStoredQuantity
 };

--- a/frontend/src/pages/items/ItemsPage.jsx
+++ b/frontend/src/pages/items/ItemsPage.jsx
@@ -908,14 +908,6 @@ export default function ItemsPage({ localOnly = false } = {}) {
           </p>
         </div>
         <div className="inline-actions">
-          <button
-            type="button"
-            className="secondary-button"
-            aria-pressed={localOnly}
-            onClick={() => navigate(localOnly ? '/items' : '/items/local', { replace: true })}
-          >
-            {localOnly ? 'Ver todos los artículos' : 'Ver solo artículos locales'}
-          </button>
           <span className="badge">Total: {total}</span>
           {canWrite && (
             <button type="button" onClick={handleMarkAllForRecount} disabled={markingAllRecount || total === 0}>


### PR DESCRIPTION
### Motivation
- Al enviar artículos a ubicaciones marcadas como `isLocal`, las cajas deben contarse como unidades multiplicadas por `unitsPerBox` y no dejar cajas en stock local; si no hay `unitsPerBox` cargado, la operación debe fallar con un mensaje claro.
- Reutilizar la misma lógica para recepciones por códigos de barra hacia locales para mantener consistencia en la carga de stock.
- Simplificar la interfaz de artículos ocultando los botones de alternar vista local/global porque el filtro a nivel de sección ya es suficiente.

### Description
- Añadida la función `normalizeQuantityForLocalDestination(quantity, item, toLocation)` en `backend/src/services/stockService.js` que convierte `boxes` a `units` multiplicando por `item.unitsPerBox` cuando `toLocation.isLocal` es verdadero y lanza `HttpError(400)` si `unitsPerBox` no está definido o es inválido.
- Modificada `validateMovementPayload` en `backend/src/services/stockService.js` para obtener el `item` y aplicar la conversión antes de devolver la cantidad y guardarla en la solicitud.
- Aplicada la misma conversión en la ruta de `barcode-reception` (`backend/src/routes/stock.js`) para que las recepciones hacia locales importen unidades en destino en lugar de cajas.
- Eliminado el botón de alternancia "Ver solo artículos locales / Ver todos los artículos" en `frontend/src/pages/items/ItemsPage.jsx`, dejando sólo el contador `Total` y las acciones pertinentes.

### Testing
- Ejecutado `npm test --prefix backend` que terminó correctamente (mensaje informativo: "No hay pruebas automatizadas definidas").
- Ejecutado `npm run build --prefix frontend` y la compilación de producción completó correctamente con Vite (`built in ...`).
- Los archivos modificados clave fueron `backend/src/services/stockService.js`, `backend/src/routes/stock.js` y `frontend/src/pages/items/ItemsPage.jsx` y la sintaxis fue validada localmente con `node -c` antes de la compilación.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a737cdf6bbc832ab13eb73265ed2b2a)