### PR TITLE
Support local destinations in movement type resolution and stock adjustments

### DIFF
--- a/backend/src/routes/stock.js
+++ b/backend/src/routes/stock.js
@@ -175,6 +175,7 @@ function serializeLocationSummary(location) {
     name: location.name,
     description: location.description || '',
     type: location.type,
+    isLocal: Boolean(location.isLocal),
     contactInfo: location.contactInfo || ''
   };
 }
@@ -183,7 +184,7 @@ function determineMovementType(fromLocation, toLocation) {
   if (fromLocation && fromLocation.type === 'externalOrigin') {
     return 'ingress';
   }
-  if (toLocation && toLocation.type === 'external') {
+  if (toLocation && (toLocation.type === 'external' || toLocation.isLocal)) {
     return 'egress';
   }
   return 'transfer';

--- a/backend/src/services/stockService.js
+++ b/backend/src/services/stockService.js
@@ -164,7 +164,7 @@ function inferMovementType(fromLocation, toLocation) {
   if (fromLocation?.type === 'externalOrigin') {
     return 'ingress';
   }
-  if (toLocation?.type === 'external') {
+  if (toLocation?.type === 'external' || toLocation?.isLocal) {
     return 'egress';
   }
   return 'transfer';
@@ -186,16 +186,17 @@ async function executeMovement(request, actorUserId, metadata = {}) {
   ]);
 
   const movementType = inferMovementType(fromLocation, toLocation);
+  const destinationQuantity = normalizeQuantityForLocalDestination(quantity, item, toLocation);
 
   // Actualizar el tipo almacenado en caso de que se haya guardado incorrectamente
   request.type = movementType;
 
-  if (movementType !== 'ingress') {
+  if (fromLocation.type !== 'externalOrigin') {
     adjustItemStock(item, fromLocationId, negateQuantity(quantity));
   }
 
-  if (movementType !== 'egress') {
-    adjustItemStock(item, toLocationId, quantity);
+  if (toLocation.type !== 'external') {
+    adjustItemStock(item, toLocationId, destinationQuantity);
   }
   await item.save();
 
@@ -247,10 +248,8 @@ async function validateMovementPayload(payload) {
     })
   ]);
 
-  const quantity = normalizeQuantityForLocalDestination(inputQuantity, item, toLocation);
-
   return {
-    quantity,
+    quantity: inputQuantity,
     fromLocation,
     toLocation,
     item
@@ -265,5 +264,6 @@ module.exports = {
   ensureLocationExists,
   normalizeQuantityInput,
   normalizeQuantityForLocalDestination,
-  normalizeStoredQuantity
+  normalizeStoredQuantity,
+  inferMovementType
 };

--- a/frontend/src/pages/items/BarcodeReceptionPage.jsx
+++ b/frontend/src/pages/items/BarcodeReceptionPage.jsx
@@ -152,7 +152,11 @@ export default function BarcodeReceptionPage() {
   const selectedDestination = useMemo(() => locations.find(location => location.id === destinationLocationId), [locations, destinationLocationId]);
   const currentMovementType = useMemo(() => {
     if (!selectedOrigin || !selectedDestination) return null;
-    return resolveMovementType({ fromType: selectedOrigin.type, toType: selectedDestination.type });
+    return resolveMovementType({
+      fromType: selectedOrigin.type,
+      toType: selectedDestination.type,
+      toIsLocal: selectedDestination.isLocal
+    });
   }, [selectedDestination, selectedOrigin]);
 
   useEffect(() => {

--- a/frontend/src/pages/movements/ApprovalsPage.jsx
+++ b/frontend/src/pages/movements/ApprovalsPage.jsx
@@ -156,7 +156,8 @@ export default function ApprovalsPage() {
                   const movementType = resolveMovementType({
                     explicitType: request.type,
                     fromType: request.fromLocation?.type,
-                    toType: request.toLocation?.type
+                    toType: request.toLocation?.type,
+                    toIsLocal: request.toLocation?.isLocal
                   });
                   const movementBadgeClass =
                     MOVEMENT_TYPE_BADGE_CLASS[movementType] || MOVEMENT_TYPE_BADGE_CLASS.transfer;

--- a/frontend/src/pages/movements/MovementRequestsPage.jsx
+++ b/frontend/src/pages/movements/MovementRequestsPage.jsx
@@ -272,7 +272,8 @@ export default function MovementRequestsPage() {
     return resolveMovementType({
       explicitType: null,
       fromType: fromLocation?.type,
-      toType: toLocation?.type
+      toType: toLocation?.type,
+      toIsLocal: toLocation?.isLocal
     });
   }, [formValues.fromLocation, formValues.toLocation, locationMap]);
 
@@ -805,7 +806,8 @@ export default function MovementRequestsPage() {
                   const movementType = resolveMovementType({
                     explicitType: request.type,
                     fromType: request.fromLocation?.type,
-                    toType: request.toLocation?.type
+                    toType: request.toLocation?.type,
+                    toIsLocal: request.toLocation?.isLocal
                   });
                   const movementBadgeClass =
                     MOVEMENT_TYPE_BADGE_CLASS[movementType] || MOVEMENT_TYPE_BADGE_CLASS.transfer;

--- a/frontend/src/utils/movements.js
+++ b/frontend/src/utils/movements.js
@@ -10,14 +10,14 @@ export const MOVEMENT_TYPE_BADGE_CLASS = Object.freeze({
   egress: 'movement-egress'
 });
 
-export function resolveMovementType({ explicitType, fromType, toType }) {
+export function resolveMovementType({ explicitType, fromType, toType, toIsLocal = false }) {
   if (explicitType && ['ingress', 'egress'].includes(explicitType)) {
     return explicitType;
   }
   if (fromType === 'externalOrigin') {
     return 'ingress';
   }
-  if (toType === 'external') {
+  if (toType === 'external' || toIsLocal) {
     return 'egress';
   }
   if (explicitType && MOVEMENT_TYPE_LABELS[explicitType]) {


### PR DESCRIPTION
### Motivation
- Treat locations marked as `isLocal` as external destinations for movement type resolution so local external-style destinations are handled consistently.
- Ensure stock adjustments correctly account for local destinations by normalizing destination quantity for local storage semantics.
- Surface the `isLocal` flag in serialized location summaries so front-end components can decide movement types and labels.

### Description
- Include `isLocal: Boolean(location.isLocal)` in `serializeLocationSummary` to explicitly expose the flag.
- Update movement type inference (`determineMovementType` / `inferMovementType`) to treat a destination with `isLocal` as an `egress` in addition to `external` destinations.
- In `executeMovement`, compute `destinationQuantity` with `normalizeQuantityForLocalDestination` and apply that when adjusting to-location stock, and avoid decrementing external origin stocks; ensure stored request `type` is updated to the inferred movement type.
- Restore returning the raw input quantity from `validateMovementPayload` (defer destination normalization to execution) and export `inferMovementType` from the service module.
- Update front-end components (`BarcodeReceptionPage`, `ApprovalsPage`, `MovementRequestsPage`, and `movements` util) to pass `toIsLocal` / `isLocal` into `resolveMovementType` so UI badges and labels reflect the new logic.

### Testing
- Ran the backend test suite (`npm test` for backend) and the frontend test/build (`yarn test` / `yarn build`) to verify integration points; all tests and build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a74e61523f8832ab33896046135720b)