### PR TITLE
Agregar lanzador y mejoras al script de respaldo previo a actualizaciones

### DIFF
--- a/docs/demo-deployment.md
+++ b/docs/demo-deployment.md
@@ -165,6 +165,26 @@ Si ya tienes una copia, actualízala con `git pull`.
 
 ### Actualizar el frontend en producción
 
+Antes de actualizar, ejecutá desde la raíz del repositorio el respaldo completo:
+
+```bash
+./respaldar_antes_de_actualizar.sh
+```
+
+El comando guarda en `../GestionThibe_backups/<fecha UTC>/` una copia de los
+archivos y configuraciones locales de la aplicación (incluidos los uploads), un
+dump comprimido de MongoDB, las sumas SHA-256 y, cuando está disponible, el
+estado de PM2. Lee `MONGO_URI` desde `backend/.env`; requiere
+`mongodump` (MongoDB Database Tools) y no deja una carpeta parcial si el respaldo
+falla. Para elegir otro disco o carpeta, ejecutá por ejemplo:
+
+```bash
+BACKUP_ROOT=/mnt/backups/gestionthibe ./respaldar_antes_de_actualizar.sh
+```
+
+No continúes con la actualización si el comando no termina con el mensaje
+`Backup terminado correctamente`.
+
 Un `git pull` solo actualiza el código fuente: la interfaz publicada no cambia hasta volver a generar los archivos estáticos. Desde la raíz del repositorio, después de traer el commit, ejecuta:
 
 ```bash

--- a/respaldar_antes_de_actualizar.sh
+++ b/respaldar_antes_de_actualizar.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+# Lanzador corto para el respaldo completo de produccion. Mantener la logica en
+# scripts/backup_production.sh permite usar el mismo procedimiento manualmente o
+# desde una tarea programada.
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+exec "${REPO_DIR}/scripts/backup_production.sh" "$@"

--- a/scripts/backup_production.sh
+++ b/scripts/backup_production.sh
@@ -1,6 +1,35 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
+usage() {
+  cat <<'USAGE'
+Uso:
+  ./respaldar_antes_de_actualizar.sh
+
+El respaldo incluye el codigo y la configuracion local de la aplicacion,
+uploads, MongoDB y, si existe, el estado de PM2. Por defecto se guarda en una
+carpeta hermana del repositorio llamada GestionThibe_backups.
+
+Variables opcionales:
+  BACKUP_ROOT   Carpeta donde guardar los respaldos
+  APP_DIR       Carpeta de la aplicacion
+  MONGO_URI     Conexion a MongoDB (si no se usa backend/.env)
+  MONGO_DB_NAME Base local usada cuando MONGO_URI no esta configurada
+USAGE
+}
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  usage
+  exit 0
+fi
+
+if [[ $# -gt 0 ]]; then
+  usage >&2
+  echo >&2
+  echo "ERROR: opcion desconocida: $1" >&2
+  exit 2
+fi
+
 APP_DIR="${APP_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 BACKUP_ROOT="${BACKUP_ROOT:-${APP_DIR}_backups}"
 STAMP="$(date -u +%Y%m%dT%H%M%SZ)"
@@ -38,6 +67,15 @@ read_env_value() {
 
 mkdir -p "$BACKUP_DIR"
 chmod 700 "$BACKUP_DIR"
+
+backup_complete=false
+cleanup_incomplete_backup() {
+  if [[ "$backup_complete" != "true" ]]; then
+    log "Eliminando respaldo incompleto: $BACKUP_DIR"
+    rm -rf -- "$BACKUP_DIR"
+  fi
+}
+trap cleanup_incomplete_backup EXIT
 
 log "Aplicación: $APP_DIR"
 log "Destino: $BACKUP_DIR"
@@ -96,6 +134,8 @@ fi
 
 sha256sum "${BACKUP_DIR}/${ARCHIVE_NAME}" "${BACKUP_DIR}/${MONGO_ARCHIVE_NAME}" > "${BACKUP_DIR}/SHA256SUMS"
 chmod 600 "${BACKUP_DIR}/SHA256SUMS" "$MANIFEST_FILE"
+
+backup_complete=true
 
 log "Backup terminado correctamente."
 log "Carpeta: $BACKUP_DIR"


### PR DESCRIPTION
### Motivation

- Facilitar la creación de un respaldo completo antes de actualizar la aplicación para reducir el riesgo de pérdida de datos.
- Evitar dejar carpetas de respaldo parciales cuando falla alguna parte del proceso (por ejemplo `mongodump`).

### Description

- Añadido el lanzador ejecutable `respaldar_antes_de_actualizar.sh` que delega a `scripts/backup_production.sh` para ejecutar el respaldo con un comando sencillo (`./respaldar_antes_de_actualizar.sh`).
- Mejorada la ayuda y validación de `scripts/backup_production.sh` con una función `usage`, soporte `--help` y rechazo de argumentos desconocidos; las variables `BACKUP_ROOT`, `APP_DIR`, `MONGO_URI` y `MONGO_DB_NAME` se pueden usar para personalizar el destino y la conexión.
- Implementada limpieza automática de respaldos incompletos mediante la variable `backup_complete` y un `trap` que elimina la carpeta de backup si el proceso no termina correctamente, y se mantiene la generación de `manifest.txt` y `SHA256SUMS`.
- Documentada la recomendación de ejecutar el respaldo antes de actualizar en `docs/demo-deployment.md` e incluido un ejemplo para cambiar el destino con `BACKUP_ROOT`.

### Testing

- `bash -n respaldar_antes_de_actualizar.sh scripts/backup_production.sh scripts/restore_production.sh` se ejecutó sin errores.
- `./respaldar_antes_de_actualizar.sh --help` mostró la ayuda esperada y finalizó correctamente.
- Prueba integral con `mongodump` simulado creó los archivos `app-*.tar.gz`, `mongo-*.archive.gz` y `SHA256SUMS`, y la verificación `sha256sum -c SHA256SUMS` devolvió `OK`.
- Simulación de fallo de `mongodump` devolvió código de salida `1` y confirmó que la carpeta de backup incompleta fue eliminada (limpieza automática exitosa).
- `git diff --check` pasó sin advertencias; `shellcheck` no está instalado en el entorno (marcado como advertencia manual).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a75c96df6e4832a8cf0ebf768c70dcd)