### PR TITLE
Separar catálogo por tipo de depósito: cajas (depósitos) vs unidades (locales)

### DIFF
--- a/backend/src/routes/items.js
+++ b/backend/src/routes/items.js
@@ -506,11 +506,8 @@ function escapeRegex(value) {
 }
 
 
-function buildPositiveStockFilters(locationIds) {
-  return locationIds.flatMap(locationId => [
-    { [`stock.${locationId}.boxes`]: { $gt: 0 } },
-    { [`stock.${locationId}.units`]: { $gt: 0 } }
-  ]);
+function buildPositiveStockFilters(locationIds, stockField) {
+  return locationIds.map(locationId => ({ [`stock.${locationId}.${stockField}`]: { $gt: 0 } }));
 }
 
 function appendAndFilter(filter, condition) {
@@ -547,7 +544,10 @@ router.get(
       await ensureItemSkus();
     }
 
-    const { page = '1', pageSize = '20', groupId, locationId, search, sku, gender, size, color, localOnly } = req.query || {};
+    const {
+      page = '1', pageSize = '20', groupId, locationId, search, sku, gender, size, color,
+      localOnly, catalogScope
+    } = req.query || {};
     const pageNumber = Math.max(parseInt(page, 10) || 1, 1);
     const limit = Math.min(Math.max(parseInt(pageSize, 10) || 20, 1), 200);
     const filter = { deletedAt: null };
@@ -565,18 +565,30 @@ router.get(
       return res.json({ total: 0, page: pageNumber, pageSize: limit, items: [] });
     }
 
-    const shouldFilterLocalOnly = ['true', '1', 'yes', 'si', 'sí', 's'].includes(
+    const legacyLocalOnly = ['true', '1', 'yes', 'si', 'sí', 's'].includes(
       String(localOnly || '').trim().toLowerCase()
     );
-    if (shouldFilterLocalOnly) {
-      const localLocationIds = normalizedLocationId
-        ? (await Location.exists({ _id: normalizedLocationId, type: 'warehouse', isLocal: true })
+    const normalizedCatalogScope = String(catalogScope || '').trim();
+    const scopedCatalog = normalizedCatalogScope === 'local' || normalizedCatalogScope === 'nonLocal';
+    const shouldFilterLocalOnly = normalizedCatalogScope === 'local' || legacyLocalOnly;
+    if (scopedCatalog || shouldFilterLocalOnly) {
+      const locationCriteria = {
+        type: 'warehouse',
+        isLocal: shouldFilterLocalOnly ? true : { $ne: true }
+      };
+      const scopedLocationIds = normalizedLocationId
+        ? (await Location.exists({ _id: normalizedLocationId, ...locationCriteria })
             ? [normalizedLocationId]
             : [])
-        : (await Location.find({ type: 'warehouse', isLocal: true }).select('_id').lean()).map(location =>
+        : (await Location.find(locationCriteria).select('_id').lean()).map(location =>
             String(location._id)
           );
-      const positiveStockFilters = buildPositiveStockFilters(localLocationIds);
+      // Cada catálogo tiene una única unidad de medida: los depósitos generales
+      // trabajan por caja y los locales mantienen su inventario interno en unidades.
+      const positiveStockFilters = buildPositiveStockFilters(
+        scopedLocationIds,
+        shouldFilterLocalOnly ? 'units' : 'boxes'
+      );
       if (positiveStockFilters.length === 0) {
         return res.json({ total: 0, page: pageNumber, pageSize: limit, items: [] });
       }

--- a/frontend/src/pages/items/ItemsPage.jsx
+++ b/frontend/src/pages/items/ItemsPage.jsx
@@ -266,9 +266,16 @@ export default function ItemsPage({ localOnly = false } = {}) {
   }, [getLocationId, locations]);
 
   const shouldIncludeLocation = useCallback(locationId => {
-    if (warehouseLocationIds.size === 0) return true;
+    if (warehouseLocationIds.size === 0) return false;
     return warehouseLocationIds.has(normalizeLocationId(locationId));
   }, [normalizeLocationId, warehouseLocationIds]);
+
+  const getCatalogQuantity = useCallback(quantity => {
+    const normalized = ensureQuantity(quantity);
+    return localOnly
+      ? { boxes: 0, units: normalized.units }
+      : { boxes: normalized.boxes, units: 0 };
+  }, [localOnly]);
 
   const shouldCountPendingRequest = useCallback(
     request => {
@@ -293,7 +300,9 @@ export default function ItemsPage({ localOnly = false } = {}) {
         setLocations(
           Array.isArray(locationsResponse)
             ? [...locationsResponse]
-                .filter(location => location.type === 'warehouse' && (!localOnly || location.isLocal === true))
+                .filter(location =>
+                  location.type === 'warehouse' && (localOnly ? location.isLocal === true : location.isLocal !== true)
+                )
                 .sort((a, b) => a.name.localeCompare(b.name, 'es', { sensitivity: 'base' }))
             : []
         );
@@ -349,7 +358,7 @@ export default function ItemsPage({ localOnly = false } = {}) {
           gender: filters.gender,
           size: filters.size,
           color: filters.color,
-          localOnly: localOnly ? 'true' : undefined
+          catalogScope: localOnly ? 'local' : 'nonLocal'
         };
         const response = await api.get('/items', { query });
         if (!active) return;
@@ -379,6 +388,7 @@ export default function ItemsPage({ localOnly = false } = {}) {
     filters.locationId,
     filters.search,
     filters.size,
+    localOnly,
     page,
     pageSize,
     updateAttributeOptionsFromItems
@@ -411,12 +421,13 @@ export default function ItemsPage({ localOnly = false } = {}) {
       map.set(
         item.id,
         computeTotalStockFromMap(stockByLocation, {
-          filterLocation: locationId => shouldIncludeLocation(locationId)
+          filterLocation: locationId => shouldIncludeLocation(locationId),
+          mapQuantity: getCatalogQuantity
         })
       );
     });
     return map;
-  }, [items, shouldIncludeLocation]);
+  }, [getCatalogQuantity, items, shouldIncludeLocation]);
 
   const itemPendingByStock = useMemo(() => {
     const map = new Map();
@@ -426,12 +437,13 @@ export default function ItemsPage({ localOnly = false } = {}) {
         item.id,
         computeTotalStockFromMap(stockByLocation, {
           preferredField: 'pending',
-          filterLocation: locationId => shouldIncludeLocation(locationId)
+          filterLocation: locationId => shouldIncludeLocation(locationId),
+          mapQuantity: getCatalogQuantity
         })
       );
     });
     return map;
-  }, [items, shouldIncludeLocation]);
+  }, [getCatalogQuantity, items, shouldIncludeLocation]);
 
   const itemStatusMap = useMemo(() => {
     const map = new Map();
@@ -903,8 +915,8 @@ export default function ItemsPage({ localOnly = false } = {}) {
           <h2>{localOnly ? 'Artículos en locales' : 'Gestión de artículos'}</h2>
           <p style={{ color: '#475569', marginTop: '-0.4rem' }}>
             {localOnly
-              ? 'Administre artículos mostrando únicamente el stock cargado en ubicaciones marcadas como Local.'
-              : 'Administre la taxonomía, atributos y stock distribuido por ubicación para cada artículo.'}
+              ? 'Artículos con stock interno en unidades dentro de ubicaciones marcadas como Local.'
+              : 'Artículos con stock por caja en depósitos que no están marcados como Local.'}
           </p>
         </div>
         <div className="inline-actions">
@@ -1208,10 +1220,11 @@ export default function ItemsPage({ localOnly = false } = {}) {
           <section className="form-section">
             <div className="form-section__header">
               <div>
-                <h3>Stock por ubicación</h3>
+                <h3>{localOnly ? 'Stock interno por local' : 'Stock por depósito'}</h3>
                 <p className="form-section__description">
-                  Registra las cantidades disponibles en cada depósito interno (opcional). También podés dejar todo en cero y
-                  cargar los movimientos desde la bandeja de transferencias.
+                  {localOnly
+                    ? 'Registra únicamente las unidades internas disponibles en cada local.'
+                    : 'Registra únicamente las cajas disponibles en cada depósito general.'}
                 </p>
               </div>
             </div>
@@ -1231,26 +1244,20 @@ export default function ItemsPage({ localOnly = false } = {}) {
                         {location.description && <p>{location.description}</p>}
                       </div>
                       <div className="form-grid form-grid--dense">
-                        <div className="input-group">
-                          <label htmlFor={`stock-${location.id}-boxes`}>Cajas</label>
-                          <input
-                            id={`stock-${location.id}-boxes`}
-                            type="number"
-                            min="0"
-                            value={entry.boxes}
-                            onChange={event => handleStockByLocationChange(location.id, 'boxes', event.target.value)}
-                          />
-                        </div>
-                        <div className="input-group">
-                          <label htmlFor={`stock-${location.id}-units`}>Unidades</label>
-                          <input
-                            id={`stock-${location.id}-units`}
-                            type="number"
-                            min="0"
-                            value={entry.units}
-                            onChange={event => handleStockByLocationChange(location.id, 'units', event.target.value)}
-                          />
-                        </div>
+                        {!localOnly && (
+                          <div className="input-group">
+                            <label htmlFor={`stock-${location.id}-boxes`}>Cajas</label>
+                            <input id={`stock-${location.id}-boxes`} type="number" min="0" value={entry.boxes}
+                              onChange={event => handleStockByLocationChange(location.id, 'boxes', event.target.value)} />
+                          </div>
+                        )}
+                        {localOnly && (
+                          <div className="input-group">
+                            <label htmlFor={`stock-${location.id}-units`}>Unidades</label>
+                            <input id={`stock-${location.id}-units`} type="number" min="0" value={entry.units}
+                              onChange={event => handleStockByLocationChange(location.id, 'units', event.target.value)} />
+                          </div>
+                        )}
                       </div>
                     </div>
                   );
@@ -1280,8 +1287,8 @@ export default function ItemsPage({ localOnly = false } = {}) {
               <h2>Consulta de artículos</h2>
               <p style={{ color: '#475569', margin: 0 }}>
                 {localOnly
-                  ? 'Tu rol permite consultar artículos y revisar únicamente cantidades de ubicaciones marcadas como Local.'
-                  : 'Tu rol permite buscar datos, revisar cantidades e imágenes, pero no crear, editar ni eliminar artículos.'}
+                  ? 'Tu rol permite consultar únicamente unidades internas de ubicaciones marcadas como Local.'
+                  : 'Tu rol permite consultar únicamente cajas de depósitos que no están marcados como Local.'}
               </p>
             </div>
           </div>
@@ -1487,7 +1494,7 @@ export default function ItemsPage({ localOnly = false } = {}) {
                           }
 
                           return stockEntries.map(([locationId, quantity]) => {
-                            const availableQuantity = resolveLocationQuantity(quantity);
+                            const availableQuantity = getCatalogQuantity(resolveLocationQuantity(quantity));
                             const normalizedId = normalizeLocationId(locationId);
                             const locationName =
                               locations.find(location => getLocationId(location) === normalizedId)?.name ||

--- a/frontend/src/utils/stockStatus.js
+++ b/frontend/src/utils/stockStatus.js
@@ -33,7 +33,7 @@ function extractQuantityByField(quantity, preferredField) {
 
 export function computeTotalStockFromMap(
   stock,
-  { preferredField = 'available', filterLocation } = {}
+  { preferredField = 'available', filterLocation, mapQuantity } = {}
 ) {
   if (!stock || typeof stock !== 'object') {
     return { boxes: 0, units: 0 };
@@ -43,7 +43,11 @@ export function computeTotalStockFromMap(
     if (filterLocation && !filterLocation(locationId, quantity)) {
       return acc;
     }
-    return sumQuantities(acc, ensureQuantity(extractQuantityByField(quantity, preferredField)));
+    const normalizedQuantity = ensureQuantity(extractQuantityByField(quantity, preferredField));
+    return sumQuantities(
+      acc,
+      typeof mapQuantity === 'function' ? ensureQuantity(mapQuantity(normalizedQuantity)) : normalizedQuantity
+    );
   }, { boxes: 0, units: 0 });
 }
 


### PR DESCRIPTION
### Motivation

- Diferenciar lo que muestran los menús "Artículos" y "Artículos Locales" para que cada uno devuelva únicamente el tipo de stock correcto (cajas en depósitos no-local vs unidades en locales). 
- Evitar mezclar unidades internas de locales con stock por caja de depósitos generales en totales, indicadores y formularios.

### Description

- Backend: se añadió el parámetro de consulta `catalogScope` y la lógica que restringe la búsqueda a ubicaciones `isLocal: true` (catálogo `local`) o `isLocal !== true` (catálogo `nonLocal`) y construye filtros sobre `stock.<location>.(units|boxes)` según el catálogo; se refactorizó `buildPositiveStockFilters` para aceptar el campo de stock a comprobar. 
- Frontend: `ItemsPage.jsx` ahora envía `catalogScope` (`local` / `nonLocal`) al API, filtra la lista de ubicaciones en base a `isLocal`, y adapta la UI para mostrar/editar únicamente `units` en el modo `local` y únicamente `boxes` en el modo no-local; además ajusta textos explicativos. 
- Utils: `computeTotalStockFromMap` en `frontend/src/utils/stockStatus.js` acepta un nuevo `mapQuantity` opcional para transformar la cantidad por ubicación (p.ej. tomar solo `units` o solo `boxes`) antes de acumular totales.

### Testing

- Ejecuté la compilación de frontend con `npm run build` y la construcción completó correctamente. 
- Ejecuté el script de tests del backend con `npm test` que solo muestra el mensaje de ausencia de pruebas automatizadas y terminó sin errores. 
- Verifiqué la sintaxis del endpoint con `node --check src/routes/items.js` y no reportó errores. 
- Añadí una comprobación de comportamiento para `computeTotalStockFromMap` mediante un pequeño script `node --input-type=module` que confirmó que los totales separan correctamente cajas y unidades y mostró `OK: los totales separan correctamente cajas de depósitos y unidades de locales.`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a79c2ba0ae8832aa39841973b1afb5c)