### PR TITLE
Add `catalogScope` filtering and units-only handling for local locations

### DIFF
--- a/backend/src/routes/items.js
+++ b/backend/src/routes/items.js
@@ -506,11 +506,10 @@ function escapeRegex(value) {
 }
 
 
-function buildPositiveStockFilters(locationIds) {
-  return locationIds.flatMap(locationId => [
-    { [`stock.${locationId}.boxes`]: { $gt: 0 } },
-    { [`stock.${locationId}.units`]: { $gt: 0 } }
-  ]);
+function buildPositiveStockFilters(locationIds, stockFields) {
+  return locationIds.flatMap(locationId =>
+    stockFields.map(stockField => ({ [`stock.${locationId}.${stockField}`]: { $gt: 0 } }))
+  );
 }
 
 function appendAndFilter(filter, condition) {
@@ -547,7 +546,10 @@ router.get(
       await ensureItemSkus();
     }
 
-    const { page = '1', pageSize = '20', groupId, locationId, search, sku, gender, size, color, localOnly } = req.query || {};
+    const {
+      page = '1', pageSize = '20', groupId, locationId, search, sku, gender, size, color,
+      localOnly, catalogScope
+    } = req.query || {};
     const pageNumber = Math.max(parseInt(page, 10) || 1, 1);
     const limit = Math.min(Math.max(parseInt(pageSize, 10) || 20, 1), 200);
     const filter = { deletedAt: null };
@@ -565,18 +567,30 @@ router.get(
       return res.json({ total: 0, page: pageNumber, pageSize: limit, items: [] });
     }
 
-    const shouldFilterLocalOnly = ['true', '1', 'yes', 'si', 'sí', 's'].includes(
+    const legacyLocalOnly = ['true', '1', 'yes', 'si', 'sí', 's'].includes(
       String(localOnly || '').trim().toLowerCase()
     );
-    if (shouldFilterLocalOnly) {
-      const localLocationIds = normalizedLocationId
-        ? (await Location.exists({ _id: normalizedLocationId, type: 'warehouse', isLocal: true })
+    const normalizedCatalogScope = String(catalogScope || '').trim();
+    const scopedCatalog = normalizedCatalogScope === 'local' || normalizedCatalogScope === 'nonLocal';
+    const shouldFilterLocalOnly = normalizedCatalogScope === 'local' || legacyLocalOnly;
+    if (scopedCatalog || shouldFilterLocalOnly) {
+      const locationCriteria = {
+        type: 'warehouse',
+        isLocal: shouldFilterLocalOnly ? true : { $ne: true }
+      };
+      const scopedLocationIds = normalizedLocationId
+        ? (await Location.exists({ _id: normalizedLocationId, ...locationCriteria })
             ? [normalizedLocationId]
             : [])
-        : (await Location.find({ type: 'warehouse', isLocal: true }).select('_id').lean()).map(location =>
+        : (await Location.find(locationCriteria).select('_id').lean()).map(location =>
             String(location._id)
           );
-      const positiveStockFilters = buildPositiveStockFilters(localLocationIds);
+      // Los locales administran únicamente unidades internas. Los depósitos
+      // generales conservan el detalle tradicional de cajas y unidades.
+      const positiveStockFilters = buildPositiveStockFilters(
+        scopedLocationIds,
+        shouldFilterLocalOnly ? ['units'] : ['boxes', 'units']
+      );
       if (positiveStockFilters.length === 0) {
         return res.json({ total: 0, page: pageNumber, pageSize: limit, items: [] });
       }

--- a/frontend/src/pages/items/ItemsPage.jsx
+++ b/frontend/src/pages/items/ItemsPage.jsx
@@ -266,9 +266,24 @@ export default function ItemsPage({ localOnly = false } = {}) {
   }, [getLocationId, locations]);
 
   const shouldIncludeLocation = useCallback(locationId => {
-    if (warehouseLocationIds.size === 0) return true;
+    if (warehouseLocationIds.size === 0) return false;
     return warehouseLocationIds.has(normalizeLocationId(locationId));
   }, [normalizeLocationId, warehouseLocationIds]);
+
+  const getCatalogQuantity = useCallback(quantity => {
+    const normalized = ensureQuantity(quantity);
+    return localOnly
+      ? { boxes: 0, units: normalized.units }
+      : normalized;
+  }, [localOnly]);
+
+  const formatCatalogQuantity = useCallback((quantity, { compact = false } = {}) => {
+    const normalized = ensureQuantity(quantity);
+    if (localOnly) {
+      return compact ? `${normalized.units}u` : `${normalized.units} unidades`;
+    }
+    return formatQuantity(normalized, { compact });
+  }, [localOnly]);
 
   const shouldCountPendingRequest = useCallback(
     request => {
@@ -293,7 +308,9 @@ export default function ItemsPage({ localOnly = false } = {}) {
         setLocations(
           Array.isArray(locationsResponse)
             ? [...locationsResponse]
-                .filter(location => location.type === 'warehouse' && (!localOnly || location.isLocal === true))
+                .filter(location =>
+                  location.type === 'warehouse' && (localOnly ? location.isLocal === true : location.isLocal !== true)
+                )
                 .sort((a, b) => a.name.localeCompare(b.name, 'es', { sensitivity: 'base' }))
             : []
         );
@@ -349,7 +366,7 @@ export default function ItemsPage({ localOnly = false } = {}) {
           gender: filters.gender,
           size: filters.size,
           color: filters.color,
-          localOnly: localOnly ? 'true' : undefined
+          catalogScope: localOnly ? 'local' : 'nonLocal'
         };
         const response = await api.get('/items', { query });
         if (!active) return;
@@ -379,6 +396,7 @@ export default function ItemsPage({ localOnly = false } = {}) {
     filters.locationId,
     filters.search,
     filters.size,
+    localOnly,
     page,
     pageSize,
     updateAttributeOptionsFromItems
@@ -411,12 +429,13 @@ export default function ItemsPage({ localOnly = false } = {}) {
       map.set(
         item.id,
         computeTotalStockFromMap(stockByLocation, {
-          filterLocation: locationId => shouldIncludeLocation(locationId)
+          filterLocation: locationId => shouldIncludeLocation(locationId),
+          mapQuantity: getCatalogQuantity
         })
       );
     });
     return map;
-  }, [items, shouldIncludeLocation]);
+  }, [getCatalogQuantity, items, shouldIncludeLocation]);
 
   const itemPendingByStock = useMemo(() => {
     const map = new Map();
@@ -426,12 +445,13 @@ export default function ItemsPage({ localOnly = false } = {}) {
         item.id,
         computeTotalStockFromMap(stockByLocation, {
           preferredField: 'pending',
-          filterLocation: locationId => shouldIncludeLocation(locationId)
+          filterLocation: locationId => shouldIncludeLocation(locationId),
+          mapQuantity: getCatalogQuantity
         })
       );
     });
     return map;
-  }, [items, shouldIncludeLocation]);
+  }, [getCatalogQuantity, items, shouldIncludeLocation]);
 
   const itemStatusMap = useMemo(() => {
     const map = new Map();
@@ -903,8 +923,8 @@ export default function ItemsPage({ localOnly = false } = {}) {
           <h2>{localOnly ? 'Artículos en locales' : 'Gestión de artículos'}</h2>
           <p style={{ color: '#475569', marginTop: '-0.4rem' }}>
             {localOnly
-              ? 'Administre artículos mostrando únicamente el stock cargado en ubicaciones marcadas como Local.'
-              : 'Administre la taxonomía, atributos y stock distribuido por ubicación para cada artículo.'}
+              ? 'Artículos con stock interno en unidades dentro de ubicaciones marcadas como Local.'
+              : 'Artículos con stock en cajas y unidades de depósitos que no están marcados como Local.'}
           </p>
         </div>
         <div className="inline-actions">
@@ -1208,10 +1228,11 @@ export default function ItemsPage({ localOnly = false } = {}) {
           <section className="form-section">
             <div className="form-section__header">
               <div>
-                <h3>Stock por ubicación</h3>
+                <h3>{localOnly ? 'Stock interno por local' : 'Stock por depósito'}</h3>
                 <p className="form-section__description">
-                  Registra las cantidades disponibles en cada depósito interno (opcional). También podés dejar todo en cero y
-                  cargar los movimientos desde la bandeja de transferencias.
+                  {localOnly
+                    ? 'Registra únicamente las unidades internas disponibles en cada local.'
+                    : 'Registra las cajas y unidades disponibles en cada depósito general.'}
                 </p>
               </div>
             </div>
@@ -1231,25 +1252,17 @@ export default function ItemsPage({ localOnly = false } = {}) {
                         {location.description && <p>{location.description}</p>}
                       </div>
                       <div className="form-grid form-grid--dense">
-                        <div className="input-group">
-                          <label htmlFor={`stock-${location.id}-boxes`}>Cajas</label>
-                          <input
-                            id={`stock-${location.id}-boxes`}
-                            type="number"
-                            min="0"
-                            value={entry.boxes}
-                            onChange={event => handleStockByLocationChange(location.id, 'boxes', event.target.value)}
-                          />
-                        </div>
+                        {!localOnly && (
+                          <div className="input-group">
+                            <label htmlFor={`stock-${location.id}-boxes`}>Cajas</label>
+                            <input id={`stock-${location.id}-boxes`} type="number" min="0" value={entry.boxes}
+                              onChange={event => handleStockByLocationChange(location.id, 'boxes', event.target.value)} />
+                          </div>
+                        )}
                         <div className="input-group">
                           <label htmlFor={`stock-${location.id}-units`}>Unidades</label>
-                          <input
-                            id={`stock-${location.id}-units`}
-                            type="number"
-                            min="0"
-                            value={entry.units}
-                            onChange={event => handleStockByLocationChange(location.id, 'units', event.target.value)}
-                          />
+                          <input id={`stock-${location.id}-units`} type="number" min="0" value={entry.units}
+                            onChange={event => handleStockByLocationChange(location.id, 'units', event.target.value)} />
                         </div>
                       </div>
                     </div>
@@ -1280,8 +1293,8 @@ export default function ItemsPage({ localOnly = false } = {}) {
               <h2>Consulta de artículos</h2>
               <p style={{ color: '#475569', margin: 0 }}>
                 {localOnly
-                  ? 'Tu rol permite consultar artículos y revisar únicamente cantidades de ubicaciones marcadas como Local.'
-                  : 'Tu rol permite buscar datos, revisar cantidades e imágenes, pero no crear, editar ni eliminar artículos.'}
+                  ? 'Tu rol permite consultar únicamente unidades internas de ubicaciones marcadas como Local.'
+                  : 'Tu rol permite consultar cajas y unidades de depósitos que no están marcados como Local.'}
               </p>
             </div>
           </div>
@@ -1487,7 +1500,7 @@ export default function ItemsPage({ localOnly = false } = {}) {
                           }
 
                           return stockEntries.map(([locationId, quantity]) => {
-                            const availableQuantity = resolveLocationQuantity(quantity);
+                            const availableQuantity = getCatalogQuantity(resolveLocationQuantity(quantity));
                             const normalizedId = normalizeLocationId(locationId);
                             const locationName =
                               locations.find(location => getLocationId(location) === normalizedId)?.name ||
@@ -1495,14 +1508,14 @@ export default function ItemsPage({ localOnly = false } = {}) {
                             return (
                               <span key={locationId} className="badge">
                                 {locationName} ·
-                                {formatQuantity(availableQuantity, { compact: true })}
+                                {formatCatalogQuantity(availableQuantity, { compact: true })}
                               </span>
                             );
                           });
                         })()}
                       </div>
                       </td>
-                      <td>{formatQuantity(totalQuantity)}</td>
+                      <td>{formatCatalogQuantity(totalQuantity)}</td>
                       <td>
                         {item.needsRecount ? (
                           <span className="badge" style={{ backgroundColor: '#f97316', color: '#fff' }}>

--- a/frontend/src/utils/stockStatus.js
+++ b/frontend/src/utils/stockStatus.js
@@ -33,7 +33,7 @@ function extractQuantityByField(quantity, preferredField) {
 
 export function computeTotalStockFromMap(
   stock,
-  { preferredField = 'available', filterLocation } = {}
+  { preferredField = 'available', filterLocation, mapQuantity } = {}
 ) {
   if (!stock || typeof stock !== 'object') {
     return { boxes: 0, units: 0 };
@@ -43,7 +43,11 @@ export function computeTotalStockFromMap(
     if (filterLocation && !filterLocation(locationId, quantity)) {
       return acc;
     }
-    return sumQuantities(acc, ensureQuantity(extractQuantityByField(quantity, preferredField)));
+    const normalizedQuantity = ensureQuantity(extractQuantityByField(quantity, preferredField));
+    return sumQuantities(
+      acc,
+      typeof mapQuantity === 'function' ? ensureQuantity(mapQuantity(normalizedQuantity)) : normalizedQuantity
+    );
   }, { boxes: 0, units: 0 });
 }
 


### PR DESCRIPTION
### Motivation
- Introduce a clear distinction between "local" and "nonLocal" catalog scopes so the UI and API can present stock differently for local stores versus general warehouses.
- Ensure local locations are treated as managing only internal units while non-local warehouses keep the traditional boxes+units representation.

### Description
- Add a `catalogScope` query parameter handling in the items route and keep legacy `localOnly` detection via `legacyLocalOnly`, and choose location queries accordingly (`isLocal: true` vs `isLocal: { $ne: true }`).
- Change `buildPositiveStockFilters` to accept `stockFields` so the backend can build filters for either `['units']` (local) or `['boxes','units']` (non-local).
- Update frontend `ItemsPage.jsx` to send `catalogScope` to the API, filter loaded locations by `isLocal` depending on `localOnly`, hide the `boxes` input for local mode, and adapt display functions by adding `getCatalogQuantity` and `formatCatalogQuantity`.
- Extend `computeTotalStockFromMap` to accept an optional `mapQuantity` mapper and apply it when summing per-location quantities so totals reflect the catalog scope.

### Testing
- Ran the existing frontend and backend automated test suite (unit and integration tests) and all tests passed.
- Manually verified that list queries include the new `catalogScope` parameter and that local mode hides box inputs and shows units-only in computed totals.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a79c2ba0ae8832aa39841973b1afb5c)