### PR TITLE
Mostrar artículos agotados en catálogo general

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "node src/index.js",
     "dev": "nodemon src/index.js",
-    "test": "node -e \"console.log('No hay pruebas automatizadas definidas')\"",
+    "test": "node --test",
     "seed:sample": "node scripts/import-sample-dataset.js",
     "sku:sync": "node scripts/sync-item-skus.js",
     "sku:status": "node scripts/sku-status.js",

--- a/backend/src/routes/items.js
+++ b/backend/src/routes/items.js
@@ -14,6 +14,10 @@ const { recordAuditEvent } = require('../services/auditService');
 const { collectGroupAndDescendantIds, buildGroupFilterValues } = require('../services/groupService');
 const { assignSkuToNewItemData, ensureItemSkus } = require('../services/skuService');
 const { permanentlyDeleteItem } = require('../services/itemTrashService');
+const {
+  buildNonLocalCatalogStockCondition,
+  buildPositiveStockFilters
+} = require('../services/itemCatalogService');
 
 const { promises: fsPromises } = fs;
 
@@ -506,12 +510,6 @@ function escapeRegex(value) {
 }
 
 
-function buildPositiveStockFilters(locationIds, stockFields) {
-  return locationIds.flatMap(locationId =>
-    stockFields.map(stockField => ({ [`stock.${locationId}.${stockField}`]: { $gt: 0 } }))
-  );
-}
-
 function appendAndFilter(filter, condition) {
   if (!condition) {
     return;
@@ -578,23 +576,33 @@ router.get(
         type: 'warehouse',
         isLocal: shouldFilterLocalOnly ? true : { $ne: true }
       };
-      const scopedLocationIds = normalizedLocationId
+      const scopedLocations = normalizedLocationId
         ? (await Location.exists({ _id: normalizedLocationId, ...locationCriteria })
-            ? [normalizedLocationId]
+            ? [{ _id: normalizedLocationId }]
             : [])
-        : (await Location.find(locationCriteria).select('_id').lean()).map(location =>
-            String(location._id)
-          );
+        : await Location.find(locationCriteria).select('_id').lean();
+      const scopedLocationIds = scopedLocations.map(location => String(location._id));
       // Los locales administran únicamente unidades internas. Los depósitos
       // generales conservan el detalle tradicional de cajas y unidades.
-      const positiveStockFilters = buildPositiveStockFilters(
-        scopedLocationIds,
-        shouldFilterLocalOnly ? ['units'] : ['boxes', 'units']
-      );
-      if (positiveStockFilters.length === 0) {
+      if (scopedLocationIds.length === 0 && (shouldFilterLocalOnly || normalizedLocationId)) {
         return res.json({ total: 0, page: pageNumber, pageSize: limit, items: [] });
       }
-      appendAndFilter(filter, { $or: positiveStockFilters });
+      if (shouldFilterLocalOnly || normalizedLocationId) {
+        appendAndFilter(filter, {
+          $or: buildPositiveStockFilters(
+            scopedLocationIds,
+            shouldFilterLocalOnly ? ['units'] : ['boxes', 'units']
+          )
+        });
+      } else {
+        const allWarehouseLocationIds = (
+          await Location.find({ type: 'warehouse' }).select('_id').lean()
+        ).map(location => String(location._id));
+        appendAndFilter(filter, buildNonLocalCatalogStockCondition({
+          nonLocalLocationIds: scopedLocationIds,
+          allWarehouseLocationIds
+        }));
+      }
     } else if (normalizedLocationId) {
       filter[`stock.${normalizedLocationId}`] = { $exists: true };
     }

--- a/backend/src/services/itemCatalogService.js
+++ b/backend/src/services/itemCatalogService.js
@@ -1,0 +1,31 @@
+function buildPositiveStockFilters(locationIds, stockFields) {
+  return locationIds.flatMap(locationId =>
+    stockFields.map(stockField => ({ [`stock.${locationId}.${stockField}`]: { $gt: 0 } }))
+  );
+}
+
+function buildNonLocalCatalogStockCondition({ nonLocalLocationIds, allWarehouseLocationIds }) {
+  const positiveNonLocalStock = buildPositiveStockFilters(
+    nonLocalLocationIds,
+    ['boxes', 'units']
+  );
+  const positiveWarehouseStock = buildPositiveStockFilters(
+    allWarehouseLocationIds,
+    ['boxes', 'units']
+  );
+
+  // Un artículo agotado no tiene stock positivo que permita asociarlo a un
+  // depósito. Debe seguir visible en el catálogo general para poder reponerlo.
+  // Los artículos que sólo tienen existencias en locales permanecen fuera.
+  return {
+    $or: [
+      ...positiveNonLocalStock,
+      { $nor: positiveWarehouseStock }
+    ]
+  };
+}
+
+module.exports = {
+  buildNonLocalCatalogStockCondition,
+  buildPositiveStockFilters
+};

--- a/backend/test/itemCatalogService.test.js
+++ b/backend/test/itemCatalogService.test.js
@@ -1,0 +1,36 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  buildNonLocalCatalogStockCondition,
+  buildPositiveStockFilters
+} = require('../src/services/itemCatalogService');
+
+test('crea filtros positivos para los campos de stock indicados', () => {
+  assert.deepEqual(buildPositiveStockFilters(['deposito'], ['boxes', 'units']), [
+    { 'stock.deposito.boxes': { $gt: 0 } },
+    { 'stock.deposito.units': { $gt: 0 } }
+  ]);
+});
+
+test('el catálogo general incluye stock no local y artículos agotados', () => {
+  assert.deepEqual(
+    buildNonLocalCatalogStockCondition({
+      nonLocalLocationIds: ['general'],
+      allWarehouseLocationIds: ['general', 'local']
+    }),
+    {
+      $or: [
+        { 'stock.general.boxes': { $gt: 0 } },
+        { 'stock.general.units': { $gt: 0 } },
+        {
+          $nor: [
+            { 'stock.general.boxes': { $gt: 0 } },
+            { 'stock.general.units': { $gt: 0 } },
+            { 'stock.local.boxes': { $gt: 0 } },
+            { 'stock.local.units': { $gt: 0 } }
+          ]
+        }
+      ]
+    }
+  );
+});

--- a/frontend/src/pages/items/ItemsPage.jsx
+++ b/frontend/src/pages/items/ItemsPage.jsx
@@ -926,7 +926,7 @@ export default function ItemsPage({ localOnly = false } = {}) {
           <p style={{ color: '#475569', marginTop: '-0.4rem' }}>
             {localOnly
               ? 'Artículos con stock interno en unidades dentro de ubicaciones marcadas como Local.'
-              : 'Artículos con stock en cajas y unidades de depósitos que no están marcados como Local.'}
+              : 'Catálogo general de artículos de depósitos no locales, incluidos los que están agotados.'}
           </p>
         </div>
         <div className="inline-actions">
@@ -1296,7 +1296,7 @@ export default function ItemsPage({ localOnly = false } = {}) {
               <p style={{ color: '#475569', margin: 0 }}>
                 {localOnly
                   ? 'Tu rol permite consultar únicamente unidades internas de ubicaciones marcadas como Local.'
-                  : 'Tu rol permite consultar cajas y unidades de depósitos que no están marcados como Local.'}
+                  : 'Tu rol permite consultar el catálogo de depósitos no locales, incluidos los artículos agotados.'}
               </p>
             </div>
           </div>


### PR DESCRIPTION
### Motivation

- Después de separar las vistas de “Artículos” y “Artículos Locales”, el catálogo general dejaba fuera los artículos completamente agotados porque el filtro requería stock positivo en depósitos no locales.  
- Es necesario que el catálogo general muestre también artículos sin stock (para poder reponerlos), pero sin incluir artículos cuyo stock positivo exista exclusivamente en locales.  
- También se buscó dejar claro en la interfaz que la lista de “Artículos” incluye los agotados en depósitos no locales.

### Description

- Añade `backend/src/services/itemCatalogService.js` con `buildPositiveStockFilters` y `buildNonLocalCatalogStockCondition` para componer condiciones que incluyen stock en depósitos no locales o artículos agotados globalmente.  
- Actualiza `backend/src/routes/items.js` para usar las nuevas funciones, mejorar la resolución de ubicaciones y aplicar la lógica que mantiene fuera del catálogo los artículos con stock sólo en locales.  
- Agrega pruebas unitarias en `backend/test/itemCatalogService.test.js` que verifican la construcción de filtros positivos y la inclusión de artículos agotados en el catálogo general.  
- Ajusta `backend/package.json` para ejecutar pruebas con `node --test` y actualiza textos en `frontend/src/pages/items/ItemsPage.jsx` para aclarar que el catálogo general incluye artículos agotados.

### Testing

- Ejecuté `cd backend && npm test` y ambas pruebas definidas en `backend/test/itemCatalogService.test.js` pasaron correctamente.  
- Verifiqué sintaxis y chequeos con `cd backend && node --check src/routes/items.js` sin errores.  
- Compilé el frontend con `cd frontend && npm run build` y la tarea de build y el script de comprobación `check-items-location-filter.mjs` completaron correctamente.  
- Ejecuté `git diff --check` y la revisión automática no reportó problemas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7b60e0b968832a989eb0f5900ce4ad)