### PR TITLE
Add seasonal withdrawal alerts, integrate into dashboard, and add tests

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "test": "node --test",
     "build": "npm run check:items-location-filter && node scripts/build.mjs",
     "check:items-location-filter": "node scripts/check-items-location-filter.mjs",
     "clean": "node scripts/clean-dist.mjs",

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -7,6 +7,10 @@ import ErrorMessage from '../components/ErrorMessage.jsx';
 import { formatQuantity, ensureQuantity, sumQuantities } from '../utils/quantity.js';
 import { computeTotalStockFromMap } from '../utils/stockStatus.js';
 import { computeInventoryAlerts, RECOUNT_THRESHOLD_DAYS } from '../utils/inventoryAlerts.js';
+import {
+  computeSeasonalWithdrawalAlerts,
+  WITHDRAWAL_ALERT_DAYS
+} from '../utils/seasonalWithdrawalAlerts.js';
 
 const ATTENTION_MANUAL_LIMIT = 5;
 
@@ -63,6 +67,7 @@ export default function DashboardPage() {
   const [locations, setLocations] = useState([]);
   const [requests, setRequests] = useState([]);
   const [itemsSnapshot, setItemsSnapshot] = useState([]);
+  const [currentDate, setCurrentDate] = useState(() => new Date());
   const [topStartDate, setTopStartDate] = useState(() => {
     const startOfMonth = new Date();
     startOfMonth.setHours(0, 0, 0, 0);
@@ -95,6 +100,11 @@ export default function DashboardPage() {
     endOfMonth.setHours(0, 0, 0, 0);
     return formatDateForInput(endOfMonth);
   });
+
+  useEffect(() => {
+    const interval = window.setInterval(() => setCurrentDate(new Date()), 60 * 60 * 1000);
+    return () => window.clearInterval(interval);
+  }, []);
 
   useEffect(() => {
     let active = true;
@@ -222,9 +232,16 @@ export default function DashboardPage() {
       total: computeTotalStockFromMap(item.stock),
       updatedAt: item.updatedAt,
       group: item.group || null,
-      needsRecount: Boolean(item.needsRecount)
+      needsRecount: Boolean(item.needsRecount),
+      season: item.attributes?.season || '',
+      createdAt: item.createdAt
     }));
   }, [itemsSnapshot]);
+
+  const seasonalWithdrawalAlerts = useMemo(
+    () => computeSeasonalWithdrawalAlerts(itemSummaries, requests, { now: currentDate }),
+    [currentDate, itemSummaries, requests]
+  );
 
   const itemsById = useMemo(() => {
     const map = new Map();
@@ -621,6 +638,44 @@ export default function DashboardPage() {
               </ul>
             )}
           </Link>
+        </div>
+      )}
+
+      {canViewCatalog && canManageRequests && (
+        <div className="section-card">
+          <div className="flex-between" style={{ gap: '1rem', flexWrap: 'wrap' }}>
+            <div>
+              <h2>Artículos sin retiros recientes</h2>
+              <span style={{ color: '#64748b', fontSize: '0.85rem' }}>
+                Temporada actual: {seasonalWithdrawalAlerts.activeSeason} y artículos sin temporada
+              </span>
+            </div>
+            <span className="badge pending">{WITHDRAWAL_ALERT_DAYS}+ días</span>
+          </div>
+          {seasonalWithdrawalAlerts.alerts.length === 0 ? (
+            <p style={{ color: '#64748b', marginTop: '1rem' }}>
+              No hay artículos de la temporada actual sin retirar durante los últimos {WITHDRAWAL_ALERT_DAYS} días.
+            </p>
+          ) : (
+            <div className="table-wrapper">
+              <table>
+                <thead>
+                  <tr>
+                    <th>Código</th><th>Descripción</th><th>Temporada</th><th>Último retiro</th><th>Días sin retirar</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {seasonalWithdrawalAlerts.alerts.map(item => (
+                    <tr key={item.id}>
+                      <td>{item.code}</td><td>{item.description}</td><td>{item.season}</td>
+                      <td>{item.lastWithdrawalAt ? new Date(item.lastWithdrawalAt).toLocaleString('es-AR') : 'Nunca retirado'}</td>
+                      <td>{item.daysWithoutWithdrawal}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
         </div>
       )}
 

--- a/frontend/src/pages/items/ItemsPage.jsx
+++ b/frontend/src/pages/items/ItemsPage.jsx
@@ -8,6 +8,7 @@ import { ensureQuantity } from '../../utils/quantity.js';
 import StockStatusBadge from '../../components/StockStatusBadge.jsx';
 import { aggregatePendingByItem, computeTotalStockFromMap, deriveStockStatus } from '../../utils/stockStatus.js';
 import { API_ROOT_URL } from '../../utils/apiConfig.js';
+import { normalizeSeason } from '../../utils/seasonalWithdrawalAlerts.js';
 
 const ATTRIBUTE_FIELDS = [
   {
@@ -43,10 +44,9 @@ const ATTRIBUTE_FIELDS = [
     type: 'select',
     placeholder: 'Selecciona la temporada',
     options: [
-      { value: 'Primavera', label: 'Primavera' },
-      { value: 'Verano', label: 'Verano' },
-      { value: 'Invierno', label: 'Invierno' },
-      { value: 'Otoño', label: 'Otoño' }
+      { value: 'Otoño/Invierno', label: 'Otoño/Invierno' },
+      { value: 'Primavera/Verano', label: 'Primavera/Verano' },
+      { value: 'Sin temporada', label: 'Sin temporada' }
     ]
   },
   // otros atributos adicionales pueden configurarse agregando nuevas entradas aquí
@@ -832,7 +832,7 @@ export default function ItemsPage({ localOnly = false } = {}) {
       size: item.attributes?.size || '',
       color: item.attributes?.color || '',
       material: item.attributes?.material || '',
-      season: item.attributes?.season || '',
+      season: normalizeSeason(item.attributes?.season),
       stockByLocation
     });
   };

--- a/frontend/src/utils/seasonalWithdrawalAlerts.js
+++ b/frontend/src/utils/seasonalWithdrawalAlerts.js
@@ -1,0 +1,60 @@
+export const WITHDRAWAL_ALERT_DAYS = 30;
+
+const DAY_IN_MS = 24 * 60 * 60 * 1000;
+
+export function getCurrentSeason(date = new Date()) {
+  const month = date.getMonth();
+  return month >= 2 && month <= 7 ? 'Otoño/Invierno' : 'Primavera/Verano';
+}
+
+export function normalizeSeason(season) {
+  const value = String(season || '').trim();
+  if (value === 'Otoño' || value === 'Invierno') return 'Otoño/Invierno';
+  if (value === 'Primavera' || value === 'Verano') return 'Primavera/Verano';
+  return value;
+}
+
+export function computeSeasonalWithdrawalAlerts(
+  items,
+  requests,
+  { now = new Date(), thresholdDays = WITHDRAWAL_ALERT_DAYS } = {}
+) {
+  const nowMs = now.getTime();
+  const cutoffMs = nowMs - thresholdDays * DAY_IN_MS;
+  const activeSeason = getCurrentSeason(now);
+  const lastWithdrawalByItem = new Map();
+
+  (Array.isArray(requests) ? requests : []).forEach(request => {
+    if (request?.status !== 'executed') return;
+    const type = String(request.type || request.movementType || 'transfer').toLowerCase();
+    if (type !== 'egress') return;
+    const itemId = request.item?.id || request.itemId;
+    const withdrawalAt = request.executedAt || request.approvedAt || request.requestedAt;
+    const withdrawalMs = withdrawalAt ? new Date(withdrawalAt).getTime() : NaN;
+    if (!itemId || Number.isNaN(withdrawalMs)) return;
+    if (withdrawalMs > (lastWithdrawalByItem.get(itemId)?.time ?? -Infinity)) {
+      lastWithdrawalByItem.set(itemId, { time: withdrawalMs, value: withdrawalAt });
+    }
+  });
+
+  const alerts = (Array.isArray(items) ? items : [])
+    .filter(item => {
+      const season = normalizeSeason(item.season || item.attributes?.season);
+      return season === activeSeason || season === 'Sin temporada';
+    })
+    .map(item => {
+      const lastWithdrawal = lastWithdrawalByItem.get(item.id);
+      const referenceMs = lastWithdrawal?.time ?? new Date(item.createdAt).getTime();
+      if (Number.isNaN(referenceMs) || referenceMs > cutoffMs) return null;
+      return {
+        ...item,
+        season: normalizeSeason(item.season || item.attributes?.season),
+        lastWithdrawalAt: lastWithdrawal?.value || null,
+        daysWithoutWithdrawal: Math.max(0, Math.floor((nowMs - referenceMs) / DAY_IN_MS))
+      };
+    })
+    .filter(Boolean)
+    .sort((a, b) => b.daysWithoutWithdrawal - a.daysWithoutWithdrawal || a.code.localeCompare(b.code));
+
+  return { activeSeason, alerts };
+}

--- a/frontend/test/seasonalWithdrawalAlerts.test.js
+++ b/frontend/test/seasonalWithdrawalAlerts.test.js
@@ -1,0 +1,34 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  computeSeasonalWithdrawalAlerts,
+  getCurrentSeason,
+  normalizeSeason
+} from '../src/utils/seasonalWithdrawalAlerts.js';
+
+test('determina la temporada para el hemisferio sur', () => {
+  assert.equal(getCurrentSeason(new Date(2026, 6, 1)), 'Otoño/Invierno');
+  assert.equal(getCurrentSeason(new Date(2026, 0, 1)), 'Primavera/Verano');
+});
+
+test('mantiene compatibilidad con las temporadas anteriores', () => {
+  assert.equal(normalizeSeason('Otoño'), 'Otoño/Invierno');
+  assert.equal(normalizeSeason('Verano'), 'Primavera/Verano');
+});
+
+test('avisa artículos de temporada activa sin retiros durante 30 días', () => {
+  const now = new Date('2026-07-15T12:00:00Z');
+  const items = [
+    { id: 'old-winter', code: 'A', season: 'Otoño/Invierno', createdAt: '2026-01-01T00:00:00Z' },
+    { id: 'recent', code: 'B', season: 'Sin temporada', createdAt: '2026-01-01T00:00:00Z' },
+    { id: 'summer', code: 'C', season: 'Primavera/Verano', createdAt: '2026-01-01T00:00:00Z' },
+    { id: 'new', code: 'D', season: 'Sin temporada', createdAt: '2026-07-01T00:00:00Z' }
+  ];
+  const requests = [
+    { itemId: 'recent', type: 'egress', status: 'executed', executedAt: '2026-07-01T00:00:00Z' }
+  ];
+  const result = computeSeasonalWithdrawalAlerts(items, requests, { now });
+  assert.equal(result.activeSeason, 'Otoño/Invierno');
+  assert.deepEqual(result.alerts.map(item => item.id), ['old-winter']);
+  assert.equal(result.alerts[0].lastWithdrawalAt, null);
+});


### PR DESCRIPTION
### Motivation
- Provide visibility for items of the current season (or without season) that have not been withdrawn recently.
- Normalize season values across the UI and persist them in item edit flows for consistent reporting.
- Add automated coverage for the new seasonal alert logic.

### Description
- Added `src/utils/seasonalWithdrawalAlerts.js` implementing `computeSeasonalWithdrawalAlerts`, `getCurrentSeason`, `normalizeSeason`, and exported `WITHDRAWAL_ALERT_DAYS` constant.
- Integrated seasonal alerts into the dashboard by tracking `currentDate`, computing `seasonalWithdrawalAlerts` with `computeSeasonalWithdrawalAlerts`, and rendering a new section when the user can view catalog and manage requests.
- Extended `itemSummaries` to include `season` and `createdAt`, and updated item edit form to use `normalizeSeason` so season values are normalized in `ItemsPage.jsx` and `ATTRIBUTE_FIELDS` season options were updated.
- Added test runner script `test` to `frontend/package.json` with the command `node --test`.
- Added unit tests in `frontend/test/seasonalWithdrawalAlerts.test.js` covering season determination, normalization compatibility, and alert generation.

### Testing
- Ran the new unit tests with `node --test` which executed `frontend/test/seasonalWithdrawalAlerts.test.js` and they passed.
- Verified the dashboard code paths compiling locally by running the dev server via `npm run dev` (no runtime test failures observed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7c742a8668832a9a9628917bef9691)