### PR TITLE
Agregar paginación a las solicitudes de stock

### DIFF
--- a/backend/src/models/MovementRequest.js
+++ b/backend/src/models/MovementRequest.js
@@ -25,6 +25,9 @@ const movementRequestSchema = new Schema(
 );
 
 movementRequestSchema.index({ status: 1, requestedAt: -1 });
+movementRequestSchema.index({ requestedAt: -1 });
+movementRequestSchema.index({ requestedBy: 1, requestedAt: -1 });
+movementRequestSchema.index({ item: 1, requestedAt: -1 });
 
 movementRequestSchema.pre('validate', function ensureQuantity(next) {
   this.quantity = coerceQuantity(this.quantity);

--- a/backend/src/routes/stock.js
+++ b/backend/src/routes/stock.js
@@ -646,7 +646,12 @@ router.get(
   requireAuth,
   asyncHandler(async (req, res) => {
     ensureStockAccess(req);
-    const { status, type, from, to, itemId, itemCode, requestedBy, profile } = req.query || {};
+    const { status, type, from, to, itemId, itemCode, requestedBy, profile, page: rawPage, limit: rawLimit } = req.query || {};
+    const paginationRequested = rawPage !== undefined || rawLimit !== undefined;
+    const page = Math.max(parseInt(rawPage, 10) || 1, 1);
+    const limit = Math.min(Math.max(parseInt(rawLimit, 10) || 25, 1), 100);
+    const emptyResponse = () =>
+      res.json(paginationRequested ? { requests: [], page, limit, total: 0, totalPages: 1 } : []);
     const filter = {};
     const normalizedType = typeof type === 'string' ? type.trim() : '';
     if (status) {
@@ -659,16 +664,16 @@ router.get(
       const resolvedFromCode = normalizedItemCode ? await resolveItemIdentifier(normalizedItemCode) : null;
 
       if (normalizedItemId && !resolvedFromId) {
-        return res.json([]);
+        return emptyResponse();
       }
 
       if (normalizedItemCode && !resolvedFromCode) {
-        return res.json([]);
+        return emptyResponse();
       }
 
       let effectiveItem = resolvedFromId || resolvedFromCode;
       if (resolvedFromId && resolvedFromCode && String(resolvedFromId) !== String(resolvedFromCode)) {
-        return res.json([]);
+        return emptyResponse();
       }
 
       if (effectiveItem) {
@@ -711,7 +716,7 @@ router.get(
           .select('_id')
           .lean();
         if (!requesterDoc) {
-          return res.json([]);
+          return emptyResponse();
         }
         requesterFilter = requesterDoc._id;
       }
@@ -729,7 +734,7 @@ router.get(
       }
 
       if (!roleId) {
-        return res.json([]);
+        return emptyResponse();
       }
 
       const roleUserIds = await User.find({ role: roleId })
@@ -739,12 +744,12 @@ router.get(
 
       if (requesterFilter) {
         if (!allowedIds.has(String(requesterFilter))) {
-          return res.json([]);
+          return emptyResponse();
         }
         filter.requestedBy = requesterFilter;
       } else {
         if (allowedIds.size === 0) {
-          return res.json([]);
+          return emptyResponse();
         }
         filter.requestedBy = { $in: Array.from(allowedIds) };
       }
@@ -752,7 +757,11 @@ router.get(
       filter.requestedBy = requesterFilter;
     }
 
-    const requests = await MovementRequest.find(filter)
+    const mustFilterLegacyTypes = normalizedType && ['transfer', 'ingress', 'egress'].includes(normalizedType);
+    let total = paginationRequested && !mustFilterLegacyTypes
+      ? await MovementRequest.countDocuments(filter)
+      : 0;
+    const requestQuery = MovementRequest.find(filter)
       .populate([
         'item',
         { path: 'requestedBy', populate: 'role' },
@@ -761,11 +770,28 @@ router.get(
         'toLocation'
       ])
       .sort({ requestedAt: -1 });
+    if (paginationRequested && !mustFilterLegacyTypes) {
+      requestQuery.skip((page - 1) * limit).limit(limit);
+    }
+    const requests = await requestQuery;
     const serialized = requests.map(serializeMovementRequest);
-    const filteredByType =
-      normalizedType && ['transfer', 'ingress', 'egress'].includes(normalizedType)
+    let filteredByType =
+      mustFilterLegacyTypes
         ? serialized.filter(request => request.type === normalizedType)
         : serialized;
+    if (paginationRequested) {
+      if (mustFilterLegacyTypes) {
+        total = filteredByType.length;
+        filteredByType = filteredByType.slice((page - 1) * limit, page * limit);
+      }
+      return res.json({
+        requests: filteredByType,
+        page,
+        limit,
+        total,
+        totalPages: Math.max(1, Math.ceil(total / limit))
+      });
+    }
     res.json(filteredByType);
   })
 );

--- a/frontend/src/pages/movements/MovementRequestsPage.jsx
+++ b/frontend/src/pages/movements/MovementRequestsPage.jsx
@@ -32,6 +32,8 @@ const MOVEMENT_TYPE_OPTIONS = [
   { value: 'egress', label: 'Salidas' }
 ];
 
+const REQUESTS_PAGE_SIZE = 25;
+
 export default function MovementRequestsPage() {
   const api = useApi();
   const { user } = useAuth();
@@ -48,6 +50,8 @@ export default function MovementRequestsPage() {
   const [allLocations, setAllLocations] = useState([]);
   const [locations, setLocations] = useState([]);
   const [requests, setRequests] = useState([]);
+  const [page, setPage] = useState(1);
+  const [pagination, setPagination] = useState({ total: 0, totalPages: 1 });
   const [statusFilter, setStatusFilter] = useState('');
   const [typeFilter, setTypeFilter] = useState('');
   const [itemFilter, setItemFilter] = useState('');
@@ -70,8 +74,8 @@ export default function MovementRequestsPage() {
   const [submitting, setSubmitting] = useState(false);
   const [successMessage, setSuccessMessage] = useState('');
 
-  const refreshRequests = useCallback(async () => {
-    const query = {};
+  const refreshRequests = useCallback(async (requestedPage = page) => {
+    const query = { page: requestedPage, limit: REQUESTS_PAGE_SIZE };
     if (statusFilter) {
       query.status = statusFilter;
     }
@@ -96,7 +100,15 @@ export default function MovementRequestsPage() {
     const response = await api.get('/stock/requests', {
       query: Object.keys(query).length > 0 ? query : undefined
     });
-    return Array.isArray(response) ? response : [];
+    if (Array.isArray(response)) {
+      return { requests: response, page: 1, total: response.length, totalPages: 1 };
+    }
+    return {
+      requests: Array.isArray(response?.requests) ? response.requests : [],
+      page: Number(response?.page) || requestedPage,
+      total: Number(response?.total) || 0,
+      totalPages: Math.max(1, Number(response?.totalPages) || 1)
+    };
   }, [
     api,
     dateFilters.from,
@@ -104,9 +116,14 @@ export default function MovementRequestsPage() {
     itemFilter,
     profileFilter,
     requesterFilter,
+    page,
     statusFilter,
     typeFilter
   ]);
+
+  useEffect(() => {
+    setPage(1);
+  }, [statusFilter, typeFilter, itemFilter, profileFilter, requesterFilter, dateFilters.from, dateFilters.to]);
 
   const refreshPendingSnapshot = useCallback(async () => {
     if (!canRequest) {
@@ -124,6 +141,10 @@ export default function MovementRequestsPage() {
       return [];
     }
   }, [api, canRequest]);
+
+  useEffect(() => {
+    refreshPendingSnapshot();
+  }, [refreshPendingSnapshot]);
 
   useEffect(() => {
     let active = true;
@@ -356,16 +377,11 @@ export default function MovementRequestsPage() {
       setLoading(true);
       setError(null);
       try {
-        const data = await refreshRequests();
+        const result = await refreshRequests();
         if (!active) return;
-        setRequests(data);
-        if (canRequest) {
-          if (statusFilter === 'pending') {
-            setPendingSnapshot(data);
-          } else {
-            await refreshPendingSnapshot();
-          }
-        }
+        setRequests(result.requests);
+        setPagination({ total: result.total, totalPages: result.totalPages });
+        if (result.page !== page) setPage(result.page);
       } catch (err) {
         if (!active) return;
         setError(err);
@@ -381,7 +397,7 @@ export default function MovementRequestsPage() {
     return () => {
       active = false;
     };
-  }, [canRequest, refreshPendingSnapshot, refreshRequests, statusFilter]);
+  }, [canRequest, page, refreshRequests]);
 
   const handleFormChange = event => {
     const { name, value } = event.target;
@@ -469,13 +485,11 @@ export default function MovementRequestsPage() {
         quantityBoxes: '',
         quantityUnits: ''
       }));
-      const refreshed = await refreshRequests();
-      setRequests(refreshed);
-      if (statusFilter === 'pending') {
-        setPendingSnapshot(refreshed);
-      } else {
-        await refreshPendingSnapshot();
-      }
+      setPage(1);
+      const refreshed = await refreshRequests(1);
+      setRequests(refreshed.requests);
+      setPagination({ total: refreshed.total, totalPages: refreshed.totalPages });
+      await refreshPendingSnapshot();
     } catch (err) {
       setError(err);
     } finally {
@@ -492,12 +506,9 @@ export default function MovementRequestsPage() {
       await api.post(`/stock/request/${request.id}/resubmit`);
       setSuccessMessage('Solicitud reenviada correctamente.');
       const refreshed = await refreshRequests();
-      setRequests(refreshed);
-      if (statusFilter === 'pending') {
-        setPendingSnapshot(refreshed);
-      } else {
-        await refreshPendingSnapshot();
-      }
+      setRequests(refreshed.requests);
+      setPagination({ total: refreshed.total, totalPages: refreshed.totalPages });
+      await refreshPendingSnapshot();
     } catch (err) {
       setError(err);
     } finally {
@@ -517,6 +528,11 @@ export default function MovementRequestsPage() {
       await api.delete(`/stock/request/${request.id}`);
       setRequests(prev => prev.filter(item => item.id !== request.id));
       setPendingSnapshot(prev => prev.filter(item => item.id !== request.id));
+      setPagination(prev => ({
+        total: Math.max(0, prev.total - 1),
+        totalPages: Math.max(1, Math.ceil(Math.max(0, prev.total - 1) / REQUESTS_PAGE_SIZE))
+      }));
+      if (requests.length === 1 && page > 1) setPage(current => current - 1);
     } catch (err) {
       setError(err);
     } finally {
@@ -783,6 +799,7 @@ export default function MovementRequestsPage() {
         ) : requests.length === 0 ? (
           <p style={{ color: '#64748b' }}>No hay solicitudes registradas con el filtro seleccionado.</p>
         ) : (
+          <>
           <div className="table-wrapper table-wrapper--compact" style={{ marginTop: '1rem' }}>
             <table>
               <thead>
@@ -885,6 +902,28 @@ export default function MovementRequestsPage() {
               </tbody>
             </table>
           </div>
+          <div className="pagination-controls" aria-label="Paginación de solicitudes">
+            <button
+              type="button"
+              className="secondary-button"
+              disabled={page <= 1 || loading}
+              onClick={() => setPage(current => Math.max(1, current - 1))}
+            >
+              Anterior
+            </button>
+            <span>
+              Página {page} de {pagination.totalPages} · {pagination.total} solicitudes
+            </span>
+            <button
+              type="button"
+              className="secondary-button"
+              disabled={page >= pagination.totalPages || loading}
+              onClick={() => setPage(current => Math.min(pagination.totalPages, current + 1))}
+            >
+              Siguiente
+            </button>
+          </div>
+          </>
         )}
       </div>
     </div>


### PR DESCRIPTION
### Motivation

- Las búsquedas de solicitudes tardan y descargan toda la colección, por lo que se agregó paginación opcional para reducir carga y mejorar tiempos de respuesta. 
- Mantener compatibilidad con consumidores existentes evitando romper la respuesta actual cuando no se envían parámetros de paginación. 
- Mejorar el rendimiento de consultas frecuentes añadiendo índices sobre campos usados en filtros y ordenamiento. 

### Description

- Backend: el endpoint `GET /stock/requests` acepta opcionalmente `page` y `limit` y devuelve, cuando se usan, un objeto con `requests`, `page`, `limit`, `total` y `totalPages`, manteniendo la respuesta en forma de array si no se solicitan parámetros de paginación. 
- Backend: se añadieron índices a `MovementRequest` (`requestedAt`, `requestedBy + requestedAt`, `item + requestedAt`) para acelerar ordenamiento y filtros habituales. 
- Frontend: la página de solicitudes envía la página y el tamaño (`REQUESTS_PAGE_SIZE = 25`), mantiene estado de `page` y `pagination`, y agrega controles `Anterior`/`Siguiente` con indicador de página y total. 
- Frontend: se separó la consulta de snapshot de pendientes para no recargar siempre todas las solicitudes pendientes y se ajustó la lógica de refresco tras crear/reenviar/eliminar solicitudes para actualizar la paginación correctamente. 

### Testing

- ✅ `cd backend && npm test` — tests unitarios del backend pasaron. 
- ✅ `cd backend && node --check src/routes/stock.js` — verificación de sintaxis del archivo modificado exitosa. 
- ✅ `cd frontend && npm test` — tests unitarios del frontend pasaron. 
- ✅ `cd frontend && npm run build` — build de producción exitosa. 
- ✅ `cd /workspace/GestionThibe && git diff --check` — sin errores de diff/check detectados.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7c8432ea60832a8b3a8ff8dc0d366e)