### PR TITLE
Añade tarjeta azul y modal para «Artículos sin retiros recientes» en el Dashboard

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -703,6 +703,12 @@ th {
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
+button.alert-card {
+  width: 100%;
+  font: inherit;
+  text-align: left;
+}
+
 .alert-card--interactive:hover,
 .alert-card--interactive:focus-visible {
   transform: translateY(-2px);
@@ -729,6 +735,19 @@ th {
   color: #b91c1c;
 }
 
+.alert-card--info {
+  background-color: #eff6ff;
+  border-color: #bfdbfe;
+}
+
+.alert-card--info h3 {
+  color: #1d4ed8;
+}
+
+.alert-card--info.alert-card--interactive:focus-visible {
+  outline-color: #60a5fa;
+}
+
 .alert-card p {
   margin: 0;
   font-size: 0.85rem;
@@ -744,6 +763,27 @@ th {
 
 .alert-card li + li {
   margin-top: 0.35rem;
+}
+
+.withdrawal-alerts-modal {
+  width: min(980px, 100%);
+}
+
+.withdrawal-alerts-modal__header {
+  align-items: flex-start;
+  margin-bottom: 1rem;
+}
+
+.withdrawal-alerts-modal__header h2,
+.withdrawal-alerts-modal__header p {
+  margin: 0;
+}
+
+.withdrawal-alerts-modal__header p,
+.withdrawal-alerts-modal__empty {
+  margin-top: 0.4rem;
+  color: #64748b;
+  font-size: 0.85rem;
 }
 
 .origin-legend {

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -100,6 +100,20 @@ export default function DashboardPage() {
     endOfMonth.setHours(0, 0, 0, 0);
     return formatDateForInput(endOfMonth);
   });
+  const [showWithdrawalAlerts, setShowWithdrawalAlerts] = useState(false);
+
+  useEffect(() => {
+    if (!showWithdrawalAlerts) {
+      return undefined;
+    }
+    const handleKeyDown = event => {
+      if (event.key === 'Escape') {
+        setShowWithdrawalAlerts(false);
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [showWithdrawalAlerts]);
 
   useEffect(() => {
     const interval = window.setInterval(() => setCurrentDate(new Date()), 60 * 60 * 1000);
@@ -638,44 +652,79 @@ export default function DashboardPage() {
               </ul>
             )}
           </Link>
+          {canManageRequests && (
+            <button
+              type="button"
+              className="alert-card alert-card--info alert-card--interactive"
+              onClick={() => setShowWithdrawalAlerts(true)}
+              aria-haspopup="dialog"
+            >
+              <h3>Artículos sin retiros recientes</h3>
+              <p>
+                {seasonalWithdrawalAlerts.alerts.length === 0
+                  ? `No hay artículos sin retiros durante los últimos ${WITHDRAWAL_ALERT_DAYS} días.`
+                  : `${seasonalWithdrawalAlerts.alerts.length} artículos sin retiros durante ${WITHDRAWAL_ALERT_DAYS}+ días.`}
+              </p>
+              {seasonalWithdrawalAlerts.alerts.length > 0 && (
+                <ul>
+                  {seasonalWithdrawalAlerts.alerts.slice(0, 5).map(item => (
+                    <li key={item.id}>
+                      {item.code} · {item.daysWithoutWithdrawal} días sin retirar
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </button>
+          )}
         </div>
       )}
 
-      {canViewCatalog && canManageRequests && (
-        <div className="section-card">
-          <div className="flex-between" style={{ gap: '1rem', flexWrap: 'wrap' }}>
-            <div>
-              <h2>Artículos sin retiros recientes</h2>
-              <span style={{ color: '#64748b', fontSize: '0.85rem' }}>
-                Temporada actual: {seasonalWithdrawalAlerts.activeSeason} y artículos sin temporada
-              </span>
+      {showWithdrawalAlerts && (
+        <div className="modal-overlay" role="presentation" onMouseDown={() => setShowWithdrawalAlerts(false)}>
+          <section
+            className="modal-card withdrawal-alerts-modal"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="withdrawal-alerts-title"
+            onMouseDown={event => event.stopPropagation()}
+          >
+            <div className="flex-between withdrawal-alerts-modal__header">
+              <div>
+                <h2 id="withdrawal-alerts-title">Artículos sin retiros recientes</h2>
+                <p>
+                  Temporada actual: {seasonalWithdrawalAlerts.activeSeason} y artículos sin temporada ·{' '}
+                  {WITHDRAWAL_ALERT_DAYS}+ días
+                </p>
+              </div>
+              <button type="button" className="secondary" onClick={() => setShowWithdrawalAlerts(false)}>
+                Cerrar
+              </button>
             </div>
-            <span className="badge pending">{WITHDRAWAL_ALERT_DAYS}+ días</span>
-          </div>
-          {seasonalWithdrawalAlerts.alerts.length === 0 ? (
-            <p style={{ color: '#64748b', marginTop: '1rem' }}>
-              No hay artículos de la temporada actual sin retirar durante los últimos {WITHDRAWAL_ALERT_DAYS} días.
-            </p>
-          ) : (
-            <div className="table-wrapper">
-              <table>
-                <thead>
-                  <tr>
-                    <th>Código</th><th>Descripción</th><th>Temporada</th><th>Último retiro</th><th>Días sin retirar</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {seasonalWithdrawalAlerts.alerts.map(item => (
-                    <tr key={item.id}>
-                      <td>{item.code}</td><td>{item.description}</td><td>{item.season}</td>
-                      <td>{item.lastWithdrawalAt ? new Date(item.lastWithdrawalAt).toLocaleString('es-AR') : 'Nunca retirado'}</td>
-                      <td>{item.daysWithoutWithdrawal}</td>
+            {seasonalWithdrawalAlerts.alerts.length === 0 ? (
+              <p className="withdrawal-alerts-modal__empty">
+                No hay artículos de la temporada actual sin retirar durante los últimos {WITHDRAWAL_ALERT_DAYS} días.
+              </p>
+            ) : (
+              <div className="table-wrapper">
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Código</th><th>Descripción</th><th>Temporada</th><th>Último retiro</th><th>Días sin retirar</th>
                     </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          )}
+                  </thead>
+                  <tbody>
+                    {seasonalWithdrawalAlerts.alerts.map(item => (
+                      <tr key={item.id}>
+                        <td>{item.code}</td><td>{item.description}</td><td>{item.season}</td>
+                        <td>{item.lastWithdrawalAt ? new Date(item.lastWithdrawalAt).toLocaleString('es-AR') : 'Nunca retirado'}</td>
+                        <td>{item.daysWithoutWithdrawal}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </section>
         </div>
       )}
 


### PR DESCRIPTION
### Motivation

- Homogeneizar la sección de resumen operativo añadiendo una tercera tarjeta al lado de `Recuento pendiente` y `Artículos agotados` para mostrar de forma compacta los artículos sin retiros recientes. 
- Permitir al usuario abrir, con un solo clic, la lista completa de artículos sin retiros recientes sin salir del `Dashboard` y con cierre por botón, clic fuera o `Escape`.

### Description

- Se añadió en `frontend/src/pages/Dashboard.jsx` un botón-tarjeta interactiva que muestra un resumen (conteo y hasta 5 ejemplos) y abre un modal con la lista completa de `seasonalWithdrawalAlerts`; se añadió el estado `showWithdrawalAlerts` y el manejador de teclado para `Escape`.
- El bloque de detalle que antes estaba embebido en la página ahora se muestra dentro de un modal (`modal-overlay` / `modal-card`) con `role="dialog"` y `aria-modal="true"` para mejorar accesibilidad.
- Se añadieron estilos en `frontend/src/index.css` para la variante azul claro de la tarjeta (`.alert-card--info`), soporte visual para botones-tarjeta (`button.alert-card`) y estilos específicos del modal (`.withdrawal-alerts-modal` y sus cabeceras) para mantener la misma modalidad visual de las otras alertas.
- La interacción respeta el comportamiento existente de las otras alertas (estilo interactivo, lista previa, uso de la rejilla de alertas) y sólo se muestra cuando el usuario tiene permisos relevantes (`canManageRequests`).

### Testing

- Se ejecutó `git diff --check` sin errores.
- Se ejecutó `cd frontend && npm test` y las 3 pruebas automatizadas existentes pasaron correctamente.
- Se ejecutó `cd frontend && npm run build` y la compilación de producción completó sin errores.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7c8bf793a8832aaa266d347f2ea9ba)