### PR TITLE
Convertir tarjeta de retiros en enlace y mostrar sección de 'retiros' en Alertas

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -703,12 +703,6 @@ th {
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
-button.alert-card {
-  width: 100%;
-  font: inherit;
-  text-align: left;
-}
-
 .alert-card--interactive:hover,
 .alert-card--interactive:focus-visible {
   transform: translateY(-2px);
@@ -763,27 +757,6 @@ button.alert-card {
 
 .alert-card li + li {
   margin-top: 0.35rem;
-}
-
-.withdrawal-alerts-modal {
-  width: min(980px, 100%);
-}
-
-.withdrawal-alerts-modal__header {
-  align-items: flex-start;
-  margin-bottom: 1rem;
-}
-
-.withdrawal-alerts-modal__header h2,
-.withdrawal-alerts-modal__header p {
-  margin: 0;
-}
-
-.withdrawal-alerts-modal__header p,
-.withdrawal-alerts-modal__empty {
-  margin-top: 0.4rem;
-  color: #64748b;
-  font-size: 0.85rem;
 }
 
 .origin-legend {

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -100,20 +100,6 @@ export default function DashboardPage() {
     endOfMonth.setHours(0, 0, 0, 0);
     return formatDateForInput(endOfMonth);
   });
-  const [showWithdrawalAlerts, setShowWithdrawalAlerts] = useState(false);
-
-  useEffect(() => {
-    if (!showWithdrawalAlerts) {
-      return undefined;
-    }
-    const handleKeyDown = event => {
-      if (event.key === 'Escape') {
-        setShowWithdrawalAlerts(false);
-      }
-    };
-    window.addEventListener('keydown', handleKeyDown);
-    return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [showWithdrawalAlerts]);
 
   useEffect(() => {
     const interval = window.setInterval(() => setCurrentDate(new Date()), 60 * 60 * 1000);
@@ -653,11 +639,9 @@ export default function DashboardPage() {
             )}
           </Link>
           {canManageRequests && (
-            <button
-              type="button"
+            <Link
+              to="/inventory/alerts#withdrawal"
               className="alert-card alert-card--info alert-card--interactive"
-              onClick={() => setShowWithdrawalAlerts(true)}
-              aria-haspopup="dialog"
             >
               <h3>Artículos sin retiros recientes</h3>
               <p>
@@ -674,57 +658,8 @@ export default function DashboardPage() {
                   ))}
                 </ul>
               )}
-            </button>
+            </Link>
           )}
-        </div>
-      )}
-
-      {showWithdrawalAlerts && (
-        <div className="modal-overlay" role="presentation" onMouseDown={() => setShowWithdrawalAlerts(false)}>
-          <section
-            className="modal-card withdrawal-alerts-modal"
-            role="dialog"
-            aria-modal="true"
-            aria-labelledby="withdrawal-alerts-title"
-            onMouseDown={event => event.stopPropagation()}
-          >
-            <div className="flex-between withdrawal-alerts-modal__header">
-              <div>
-                <h2 id="withdrawal-alerts-title">Artículos sin retiros recientes</h2>
-                <p>
-                  Temporada actual: {seasonalWithdrawalAlerts.activeSeason} y artículos sin temporada ·{' '}
-                  {WITHDRAWAL_ALERT_DAYS}+ días
-                </p>
-              </div>
-              <button type="button" className="secondary" onClick={() => setShowWithdrawalAlerts(false)}>
-                Cerrar
-              </button>
-            </div>
-            {seasonalWithdrawalAlerts.alerts.length === 0 ? (
-              <p className="withdrawal-alerts-modal__empty">
-                No hay artículos de la temporada actual sin retirar durante los últimos {WITHDRAWAL_ALERT_DAYS} días.
-              </p>
-            ) : (
-              <div className="table-wrapper">
-                <table>
-                  <thead>
-                    <tr>
-                      <th>Código</th><th>Descripción</th><th>Temporada</th><th>Último retiro</th><th>Días sin retirar</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {seasonalWithdrawalAlerts.alerts.map(item => (
-                      <tr key={item.id}>
-                        <td>{item.code}</td><td>{item.description}</td><td>{item.season}</td>
-                        <td>{item.lastWithdrawalAt ? new Date(item.lastWithdrawalAt).toLocaleString('es-AR') : 'Nunca retirado'}</td>
-                        <td>{item.daysWithoutWithdrawal}</td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-            )}
-          </section>
         </div>
       )}
 

--- a/frontend/src/pages/InventoryAlerts.jsx
+++ b/frontend/src/pages/InventoryAlerts.jsx
@@ -7,6 +7,10 @@ import ErrorMessage from '../components/ErrorMessage.jsx';
 import { formatQuantity } from '../utils/quantity.js';
 import { computeTotalStockFromMap } from '../utils/stockStatus.js';
 import { computeInventoryAlerts, RECOUNT_THRESHOLD_DAYS } from '../utils/inventoryAlerts.js';
+import {
+  computeSeasonalWithdrawalAlerts,
+  WITHDRAWAL_ALERT_DAYS
+} from '../utils/seasonalWithdrawalAlerts.js';
 
 const formatUpdatedAt = value => {
   if (!value) {
@@ -60,7 +64,9 @@ const buildItemSummaries = items =>
     stock: item.stock || {},
     lastCountedAt: item.lastCountedAt || null,
     lastCountedBy: item.lastCountedBy || null,
-    total: computeTotalStockFromMap(item.stock)
+    total: computeTotalStockFromMap(item.stock),
+    season: item.attributes?.season || '',
+    createdAt: item.createdAt
   }));
 
 export default function InventoryAlertsPage() {
@@ -70,6 +76,7 @@ export default function InventoryAlertsPage() {
   const permissions = useMemo(() => user?.permissions || [], [user]);
   const canViewCatalog = permissions.includes('items.read');
   const canWrite = permissions.includes('items.write');
+  const canManageRequests = permissions.includes('stock.request') || permissions.includes('stock.approve');
 
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -78,6 +85,7 @@ export default function InventoryAlertsPage() {
   const [recountSearch, setRecountSearch] = useState('');
   const [outOfStockSearch, setOutOfStockSearch] = useState('');
   const [locations, setLocations] = useState([]);
+  const [requests, setRequests] = useState([]);
   const [editingRecount, setEditingRecount] = useState(null);
   const [recountStock, setRecountStock] = useState({});
   const [savingRecount, setSavingRecount] = useState(false);
@@ -129,6 +137,10 @@ export default function InventoryAlertsPage() {
           pageNumber += 1;
         }
         setItemsSnapshot(collectedItems);
+        if (canManageRequests) {
+          const requestsResponse = await api.get('/stock/requests');
+          setRequests(Array.isArray(requestsResponse) ? requestsResponse : []);
+        }
         if (canWrite) {
           const locationsResponse = await api.get('/locations');
           setLocations(Array.isArray(locationsResponse) ? locationsResponse : locationsResponse?.items || []);
@@ -148,7 +160,7 @@ export default function InventoryAlertsPage() {
     return () => {
       active = false;
     };
-  }, [api, canViewCatalog, canWrite]);
+  }, [api, canManageRequests, canViewCatalog, canWrite]);
 
   const locationId = location => String(location?.id || location?._id || '');
   const beginRecountEdit = item => {
@@ -192,12 +204,12 @@ export default function InventoryAlertsPage() {
       return;
     }
     const hash = location.hash?.replace('#', '');
-    if (hash === 'recount' || hash === 'out-of-stock') {
+    if (hash === 'recount' || hash === 'out-of-stock' || (hash === 'withdrawal' && canManageRequests)) {
       setActiveSection(hash);
     } else {
       setActiveSection('all');
     }
-  }, [location.hash, loading]);
+  }, [canManageRequests, location.hash, loading]);
 
   useEffect(() => {
     if (loading) {
@@ -220,6 +232,10 @@ export default function InventoryAlertsPage() {
   const { recount: recountItems, outOfStock: outOfStockItems } = useMemo(
     () => computeInventoryAlerts(itemSummaries, { thresholdDays: recountThresholdDays }),
     [itemSummaries, recountThresholdDays]
+  );
+  const seasonalWithdrawalAlerts = useMemo(
+    () => computeSeasonalWithdrawalAlerts(itemSummaries, requests),
+    [itemSummaries, requests]
   );
 
   const filteredRecountItems = useMemo(() => {
@@ -459,6 +475,51 @@ export default function InventoryAlertsPage() {
                     </div>
                   )}
                 </>
+              )}
+            </section>
+          )}
+
+          {canManageRequests && (activeSection === 'all' || activeSection === 'withdrawal') && (
+            <section className="section-card" id="withdrawal" tabIndex={-1}>
+              <div className="flex-between" style={{ alignItems: 'flex-start', gap: '1rem' }}>
+                <div>
+                  <h3>Artículos sin retiros recientes</h3>
+                  <p style={{ color: '#475569', marginTop: '-0.5rem' }}>
+                    Temporada actual: {seasonalWithdrawalAlerts.activeSeason} y artículos sin temporada ·{' '}
+                    {WITHDRAWAL_ALERT_DAYS}+ días sin retiros.
+                  </p>
+                </div>
+                <span className="badge">Total: {seasonalWithdrawalAlerts.alerts.length}</span>
+              </div>
+              {seasonalWithdrawalAlerts.alerts.length === 0 ? (
+                <p style={{ color: '#64748b', fontSize: '0.9rem', marginTop: '1rem' }}>
+                  No hay artículos de la temporada actual sin retirar durante los últimos {WITHDRAWAL_ALERT_DAYS} días.
+                </p>
+              ) : (
+                <div className="table-wrapper" style={{ marginTop: '1rem' }}>
+                  <table>
+                    <thead>
+                      <tr>
+                        <th>Código</th>
+                        <th>Descripción</th>
+                        <th>Temporada</th>
+                        <th>Último retiro</th>
+                        <th>Días sin retirar</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {seasonalWithdrawalAlerts.alerts.map(item => (
+                        <tr key={item.id}>
+                          <td>{item.code}</td>
+                          <td>{item.description}</td>
+                          <td>{item.season}</td>
+                          <td>{item.lastWithdrawalAt ? formatUpdatedAt(item.lastWithdrawalAt) : 'Nunca retirado'}</td>
+                          <td>{item.daysWithoutWithdrawal}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
               )}
             </section>
           )}


### PR DESCRIPTION
### Motivation

- Evitar el popup que aplicaba estilos que ocultaban texto y ofrecer la misma experiencia de navegación que otras tarjetas de alerta.
- Mostrar la lista completa de artículos sin retiros recientes en la página de alertas para facilitar revisión y accesibilidad.

### Description

- Reemplacé la tarjeta de "Artículos sin retiros recientes" en `Dashboard.jsx` para que sea un `Link` a `"/inventory/alerts#withdrawal"` en lugar de abrir un popup. 
- Añadí carga de `requests` (si el usuario tiene permisos) y calculé las alertas estacionales en `InventoryAlerts.jsx`, exponiendo una nueva sección `#withdrawal` con tabla y resumen. 
- Permití la navegación por fragmento para `#withdrawal` y enfoque automático del fragmento igual que otras secciones de la página. 
- Eliminé el modal y sus estilos relacionados del CSS (`index.css`) para evitar el color/estilos conflictivos y limpié reglas no usadas.

### Testing

- Ejecuté los tests unitarios con `cd frontend && npm test`, los cuales pasaron (3 tests OK). 
- Ejecuté la build de producción con `cd frontend && npm run build`, que completó correctamente sin errores.
- Verifiqué `git diff --check` localmente y no se reportaron advertencias de linter/chequeo automático.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7c8d8d47e0832a8a1a5fa7a1253a9b)