### PR TITLE
Mostrar como agotados artículos trasladados a locales

### DIFF
--- a/backend/src/routes/items.js
+++ b/backend/src/routes/items.js
@@ -14,10 +14,7 @@ const { recordAuditEvent } = require('../services/auditService');
 const { collectGroupAndDescendantIds, buildGroupFilterValues } = require('../services/groupService');
 const { assignSkuToNewItemData, ensureItemSkus } = require('../services/skuService');
 const { permanentlyDeleteItem } = require('../services/itemTrashService');
-const {
-  buildNonLocalCatalogStockCondition,
-  buildPositiveStockFilters
-} = require('../services/itemCatalogService');
+const { buildPositiveStockFilters } = require('../services/itemCatalogService');
 
 const { promises: fsPromises } = fs;
 
@@ -594,15 +591,10 @@ router.get(
             shouldFilterLocalOnly ? ['units'] : ['boxes', 'units']
           )
         });
-      } else {
-        const allWarehouseLocationIds = (
-          await Location.find({ type: 'warehouse' }).select('_id').lean()
-        ).map(location => String(location._id));
-        appendAndFilter(filter, buildNonLocalCatalogStockCondition({
-          nonLocalLocationIds: scopedLocationIds,
-          allWarehouseLocationIds
-        }));
       }
+      // Sin una ubicación puntual, el catálogo general no se filtra por stock:
+      // un artículo trasladado por completo a un local debe seguir apareciendo
+      // con total cero en depósitos no locales y estado "Agotado".
     } else if (normalizedLocationId) {
       filter[`stock.${normalizedLocationId}`] = { $exists: true };
     }

--- a/backend/src/services/itemCatalogService.js
+++ b/backend/src/services/itemCatalogService.js
@@ -4,28 +4,6 @@ function buildPositiveStockFilters(locationIds, stockFields) {
   );
 }
 
-function buildNonLocalCatalogStockCondition({ nonLocalLocationIds, allWarehouseLocationIds }) {
-  const positiveNonLocalStock = buildPositiveStockFilters(
-    nonLocalLocationIds,
-    ['boxes', 'units']
-  );
-  const positiveWarehouseStock = buildPositiveStockFilters(
-    allWarehouseLocationIds,
-    ['boxes', 'units']
-  );
-
-  // Un artículo agotado no tiene stock positivo que permita asociarlo a un
-  // depósito. Debe seguir visible en el catálogo general para poder reponerlo.
-  // Los artículos que sólo tienen existencias en locales permanecen fuera.
-  return {
-    $or: [
-      ...positiveNonLocalStock,
-      { $nor: positiveWarehouseStock }
-    ]
-  };
-}
-
 module.exports = {
-  buildNonLocalCatalogStockCondition,
   buildPositiveStockFilters
 };

--- a/backend/test/itemCatalogService.test.js
+++ b/backend/test/itemCatalogService.test.js
@@ -1,36 +1,10 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
-const {
-  buildNonLocalCatalogStockCondition,
-  buildPositiveStockFilters
-} = require('../src/services/itemCatalogService');
+const { buildPositiveStockFilters } = require('../src/services/itemCatalogService');
 
 test('crea filtros positivos para los campos de stock indicados', () => {
   assert.deepEqual(buildPositiveStockFilters(['deposito'], ['boxes', 'units']), [
     { 'stock.deposito.boxes': { $gt: 0 } },
     { 'stock.deposito.units': { $gt: 0 } }
   ]);
-});
-
-test('el catálogo general incluye stock no local y artículos agotados', () => {
-  assert.deepEqual(
-    buildNonLocalCatalogStockCondition({
-      nonLocalLocationIds: ['general'],
-      allWarehouseLocationIds: ['general', 'local']
-    }),
-    {
-      $or: [
-        { 'stock.general.boxes': { $gt: 0 } },
-        { 'stock.general.units': { $gt: 0 } },
-        {
-          $nor: [
-            { 'stock.general.boxes': { $gt: 0 } },
-            { 'stock.general.units': { $gt: 0 } },
-            { 'stock.local.boxes': { $gt: 0 } },
-            { 'stock.local.units': { $gt: 0 } }
-          ]
-        }
-      ]
-    }
-  );
 });


### PR DESCRIPTION
### Motivation

- Cuando todo el stock de un artículo se traslada a una ubicación marcada como Local, el artículo desaparecía del catálogo general en lugar de mostrarse como "Agotado", lo que impide reponerlo desde la interfaz del catálogo.

### Description

- Modificados los archivos `backend/src/services/itemCatalogService.js`, `backend/src/routes/items.js` y `backend/test/itemCatalogService.test.js` para cambiar la lógica de filtrado del catálogo general.
- Eliminada la función de filtro que excluía artículos con existencias únicamente en locales y simplificado el servicio para exponer únicamente `buildPositiveStockFilters`.
- Actualizada la ruta de listado de artículos para que, cuando no se solicite una ubicación específica, no filtre por stock de depósitos no locales y permita que los artículos con total cero en depósitos no locales sigan apareciendo con estado "Agotado".
- Ajustada la prueba unitaria para reflejar la responsabilidad restante del servicio de filtros (se eliminó la prueba que validaba la lógica previa de exclusión por stock local).

### Testing

- Ejecutado `cd backend && npm test` y todos los tests del backend pasaron correctamente.
- Ejecutado `cd frontend && npm test` y todos los tests del frontend pasaron correctamente.
- Ejecutado `cd frontend && npm run build` y la compilación de producción completó con éxito.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7cae47e6f0832a8caab4763a0fe150)