### PR TITLE
Filter seasonal withdrawal alerts to boxed stock, add boxed summaries and improve items pagination

### DIFF
--- a/frontend/src/pages/InventoryAlerts.jsx
+++ b/frontend/src/pages/InventoryAlerts.jsx
@@ -47,7 +47,7 @@ const formatRecountReasons = item => {
   return parts.join(' · ');
 };
 
-const buildItemSummaries = items =>
+const buildItemSummaries = (items, { stockLocationIds = null, boxesOnly = false } = {}) =>
   (Array.isArray(items) ? items : []).map(item => ({
     id: item.id,
     code: item.code,
@@ -64,7 +64,14 @@ const buildItemSummaries = items =>
     stock: item.stock || {},
     lastCountedAt: item.lastCountedAt || null,
     lastCountedBy: item.lastCountedBy || null,
-    total: computeTotalStockFromMap(item.stock),
+    total: computeTotalStockFromMap(item.stock, {
+      filterLocation: stockLocationIds
+        ? locationId => stockLocationIds.has(String(locationId))
+        : undefined,
+      mapQuantity: boxesOnly
+        ? quantity => ({ boxes: quantity.boxes, units: 0 })
+        : undefined
+    }),
     season: item.attributes?.season || '',
     createdAt: item.createdAt
   }));
@@ -105,46 +112,44 @@ export default function InventoryAlertsPage() {
       setLoading(true);
       setError(null);
       try {
-        const collectedItems = [];
-        const seenIds = new Set();
-        let pageNumber = 1;
-        const pageSize = 200;
-        let totalItems = null;
-        while (true) {
-          const response = await api.get('/items', { query: { page: pageNumber, pageSize } });
-          if (!active) {
-            return;
-          }
-          const pageItems = Array.isArray(response?.items) ? response.items : [];
-          pageItems.forEach(item => {
-            const id = item?.id;
-            if (id && !seenIds.has(id)) {
-              seenIds.add(id);
-              collectedItems.push(item);
+        const loadAllItems = async (query = {}) => {
+          const collectedItems = [];
+          const seenIds = new Set();
+          let pageNumber = 1;
+          const pageSize = 200;
+          let totalItems = null;
+          while (true) {
+            const response = await api.get('/items', { query: { ...query, page: pageNumber, pageSize } });
+            if (!active) return [];
+            const pageItems = Array.isArray(response?.items) ? response.items : [];
+            pageItems.forEach(item => {
+              const id = item?.id;
+              if (id && !seenIds.has(id)) {
+                seenIds.add(id);
+                collectedItems.push(item);
+              }
+            });
+            const responseTotal = Number(response?.total);
+            if (Number.isFinite(responseTotal) && responseTotal >= 0) {
+              totalItems = responseTotal;
             }
-          });
-          const responseTotal = Number(response?.total);
-          if (Number.isFinite(responseTotal) && responseTotal >= 0) {
-            totalItems = responseTotal;
+            const effectivePageSize = Number(response?.pageSize) || pageSize;
+            if (pageItems.length < effectivePageSize || (totalItems !== null && collectedItems.length >= totalItems)) {
+              break;
+            }
+            pageNumber += 1;
           }
-          const effectivePageSize = Number(response?.pageSize) || pageSize;
-          if (pageItems.length < effectivePageSize) {
-            break;
-          }
-          if (totalItems !== null && collectedItems.length >= totalItems) {
-            break;
-          }
-          pageNumber += 1;
-        }
+          return collectedItems;
+        };
+        const collectedItems = await loadAllItems();
+        if (!active) return;
         setItemsSnapshot(collectedItems);
         if (canManageRequests) {
           const requestsResponse = await api.get('/stock/requests');
           setRequests(Array.isArray(requestsResponse) ? requestsResponse : []);
         }
-        if (canWrite) {
-          const locationsResponse = await api.get('/locations');
-          setLocations(Array.isArray(locationsResponse) ? locationsResponse : locationsResponse?.items || []);
-        }
+        const locationsResponse = await api.get('/locations');
+        setLocations(Array.isArray(locationsResponse) ? locationsResponse : locationsResponse?.items || []);
       } catch (err) {
         if (!active) {
           return;
@@ -229,13 +234,22 @@ export default function InventoryAlertsPage() {
   }, [activeSection, location.hash, loading]);
 
   const itemSummaries = useMemo(() => buildItemSummaries(itemsSnapshot), [itemsSnapshot]);
+  const nonLocalWarehouseIds = useMemo(() => new Set(
+    locations
+      .filter(location => location.type === 'warehouse' && location.isLocal !== true)
+      .map(location => String(location.id || location._id))
+  ), [locations]);
+  const boxedItemSummaries = useMemo(
+    () => buildItemSummaries(itemsSnapshot, { stockLocationIds: nonLocalWarehouseIds, boxesOnly: true }),
+    [itemsSnapshot, nonLocalWarehouseIds]
+  );
   const { recount: recountItems, outOfStock: outOfStockItems } = useMemo(
     () => computeInventoryAlerts(itemSummaries, { thresholdDays: recountThresholdDays }),
     [itemSummaries, recountThresholdDays]
   );
   const seasonalWithdrawalAlerts = useMemo(
-    () => computeSeasonalWithdrawalAlerts(itemSummaries, requests),
-    [itemSummaries, requests]
+    () => computeSeasonalWithdrawalAlerts(boxedItemSummaries, requests),
+    [boxedItemSummaries, requests]
   );
 
   const filteredRecountItems = useMemo(() => {
@@ -485,8 +499,8 @@ export default function InventoryAlertsPage() {
                 <div>
                   <h3>Artículos sin retiros recientes</h3>
                   <p style={{ color: '#475569', marginTop: '-0.5rem' }}>
-                    Temporada actual: {seasonalWithdrawalAlerts.activeSeason} y artículos sin temporada ·{' '}
-                    {WITHDRAWAL_ALERT_DAYS}+ días sin retiros.
+                    Artículos con stock actual en cajas, sin incluir locales ni agotados · temporada{' '}
+                    {seasonalWithdrawalAlerts.activeSeason} y sin temporada · {WITHDRAWAL_ALERT_DAYS}+ días sin retiros.
                   </p>
                 </div>
                 <span className="badge">Total: {seasonalWithdrawalAlerts.alerts.length}</span>

--- a/frontend/src/utils/seasonalWithdrawalAlerts.js
+++ b/frontend/src/utils/seasonalWithdrawalAlerts.js
@@ -40,7 +40,8 @@ export function computeSeasonalWithdrawalAlerts(
   const alerts = (Array.isArray(items) ? items : [])
     .filter(item => {
       const season = normalizeSeason(item.season || item.attributes?.season);
-      return season === activeSeason || season === 'Sin temporada';
+      const boxes = Number(item.total?.boxes) || 0;
+      return boxes > 0 && (season === activeSeason || season === 'Sin temporada');
     })
     .map(item => {
       const lastWithdrawal = lastWithdrawalByItem.get(item.id);

--- a/frontend/test/seasonalWithdrawalAlerts.test.js
+++ b/frontend/test/seasonalWithdrawalAlerts.test.js
@@ -19,10 +19,11 @@ test('mantiene compatibilidad con las temporadas anteriores', () => {
 test('avisa artículos de temporada activa sin retiros durante 30 días', () => {
   const now = new Date('2026-07-15T12:00:00Z');
   const items = [
-    { id: 'old-winter', code: 'A', season: 'Otoño/Invierno', createdAt: '2026-01-01T00:00:00Z' },
-    { id: 'recent', code: 'B', season: 'Sin temporada', createdAt: '2026-01-01T00:00:00Z' },
-    { id: 'summer', code: 'C', season: 'Primavera/Verano', createdAt: '2026-01-01T00:00:00Z' },
-    { id: 'new', code: 'D', season: 'Sin temporada', createdAt: '2026-07-01T00:00:00Z' }
+    { id: 'old-winter', code: 'A', season: 'Otoño/Invierno', total: { boxes: 2 }, createdAt: '2026-01-01T00:00:00Z' },
+    { id: 'recent', code: 'B', season: 'Sin temporada', total: { boxes: 1 }, createdAt: '2026-01-01T00:00:00Z' },
+    { id: 'summer', code: 'C', season: 'Primavera/Verano', total: { units: 3 }, createdAt: '2026-01-01T00:00:00Z' },
+    { id: 'new', code: 'D', season: 'Sin temporada', total: { units: 1 }, createdAt: '2026-07-01T00:00:00Z' },
+    { id: 'depleted', code: 'E', season: 'Otoño/Invierno', total: { boxes: 0, units: 0 }, createdAt: '2026-01-01T00:00:00Z' }
   ];
   const requests = [
     { itemId: 'recent', type: 'egress', status: 'executed', executedAt: '2026-07-01T00:00:00Z' }
@@ -31,4 +32,14 @@ test('avisa artículos de temporada activa sin retiros durante 30 días', () => 
   assert.equal(result.activeSeason, 'Otoño/Invierno');
   assert.deepEqual(result.alerts.map(item => item.id), ['old-winter']);
   assert.equal(result.alerts[0].lastWithdrawalAt, null);
+});
+
+test('incluye únicamente artículos con stock en cajas', () => {
+  const result = computeSeasonalWithdrawalAlerts([
+    { id: 'with-boxes', code: 'A', season: 'Sin temporada', total: { boxes: 2, units: 0 }, createdAt: '2026-01-01T00:00:00Z' },
+    { id: 'with-units', code: 'B', season: 'Sin temporada', total: { boxes: 0, units: 4 }, createdAt: '2026-01-01T00:00:00Z' },
+    { id: 'depleted', code: 'C', season: 'Sin temporada', total: { boxes: 0, units: 0 }, createdAt: '2026-01-01T00:00:00Z' }
+  ], [], { now: new Date('2026-07-15T12:00:00Z') });
+
+  assert.deepEqual(result.alerts.map(item => item.id), ['with-boxes']);
 });


### PR DESCRIPTION
### Motivation

- Ensure seasonal withdrawal alerts consider only items with stock in boxes and exclude local warehouse stock.  
- Improve reliability of fetching all catalog items by handling paginated `/items` responses robustly.  

### Description

- Changed `buildItemSummaries` to accept options (`stockLocationIds`, `boxesOnly`) and pass a `filterLocation`/`mapQuantity` to `computeTotalStockFromMap` so totals can be computed for selected locations and boxes-only.  
- Added `loadAllItems` helper to fetch `/items` across pages and replaced the previous inline pagination loop with this helper.  
- Always load `locations`, compute `nonLocalWarehouseIds`, produce `boxedItemSummaries` restricted to non-local warehouses and boxes-only, and pass that to `computeSeasonalWithdrawalAlerts`.  
- Updated `computeSeasonalWithdrawalAlerts` to ignore items without boxed stock (`total.boxes > 0`) and adjusted UI copy to clarify that alerts consider boxed stock outside local locations.  
- Updated tests in `seasonalWithdrawalAlerts.test.js` to include `total` data and added a new test `incluye únicamente artículos con stock en cajas` that verifies only items with boxes are included.  

### Testing

- Ran the frontend unit tests for seasonal withdrawal logic by executing the test file `frontend/test/seasonalWithdrawalAlerts.test.js`, and the tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7f66c78700832aba64813e808edceb)